### PR TITLE
chore(web): remove debug traces and placeholders

### DIFF
--- a/apps/web/src/pages/Browse.tsx
+++ b/apps/web/src/pages/Browse.tsx
@@ -145,47 +145,23 @@ function usePersonBrowsePortrait(personName: string) {
   const onImageError = useCallback(() => {
     if (phaseRef.current === 'proxy') {
       setPhase('pending-tmdb')
-      console.info('[peoplePortrait] Emby/Jellyfin Primary failed, requesting TMDb fallback', {
-        personName,
-        proxiedUrl: getProxiedImageUrl(
-          `/api/media/images/Persons/${encodeURIComponent(personName)}/Images/Primary`,
-          ''
-        ),
-      })
       void fetch(
         `/api/discover/person-profile?name=${encodeURIComponent(personName)}`,
         { credentials: 'include' }
       )
-        .then((r) => {
-          console.info('[peoplePortrait] person-profile response', {
-            personName,
-            ok: r.ok,
-            status: r.status,
-          })
-          return r.json()
-        })
+        .then((r) => r.json())
         .then((data: { imageUrl?: string | null }) => {
           if (data?.imageUrl) {
-            console.info('[peoplePortrait] using TMDb profile image', {
-              personName,
-              imageUrlPrefix: data.imageUrl.slice(0, 48),
-            })
             setTmdbUrl(data.imageUrl)
             setPhase('tmdb')
           } else {
-            console.info('[peoplePortrait] no TMDb imageUrl (null or missing key / no match)', {
-              personName,
-              raw: data,
-            })
             setPhase('none')
           }
         })
-        .catch((err) => {
-          console.info('[peoplePortrait] person-profile fetch failed', { personName, err })
+        .catch(() => {
           setPhase('none')
         })
     } else {
-      console.info('[peoplePortrait] TMDb image also failed, showing initials', { personName })
       setPhase('none')
     }
   }, [personName])

--- a/apps/web/src/pages/PersonDetail.tsx
+++ b/apps/web/src/pages/PersonDetail.tsx
@@ -159,13 +159,6 @@ export function PersonDetailPage() {
         }
 
         const result = await response.json()
-        console.info('[peoplePortrait] person detail loaded', {
-          name: result.name,
-          hasMediaImageUrl: !!result.imageUrl,
-          tmdbFallbackImageUrl: result.tmdbFallbackImageUrl
-            ? `${String(result.tmdbFallbackImageUrl).slice(0, 56)}…`
-            : result.tmdbFallbackImageUrl,
-        })
         setData(result)
       } catch (err) {
         setError(
@@ -286,17 +279,8 @@ export function PersonDetailPage() {
 
   const handleAvatarError = () => {
     if (avatarPhase === 'media' && proxiedTmdbFallback) {
-      console.info('[peoplePortrait] header: media image error, switching to TMDb fallback', {
-        decodedName,
-        hasTmdbFallback: true,
-      })
       setAvatarPhase('tmdb')
     } else {
-      console.info('[peoplePortrait] header: showing initials', {
-        decodedName,
-        avatarPhase,
-        hadTmdbFallback: !!proxiedTmdbFallback,
-      })
       setAvatarPhase('initials')
     }
   }

--- a/apps/web/src/pages/UserDetail.tsx
+++ b/apps/web/src/pages/UserDetail.tsx
@@ -918,8 +918,6 @@ export function UserDetailPage() {
         <Tabs value={tabValue} onChange={handleTabChange} sx={{ px: 2, pt: 1 }}>
           <Tab label={t('admin.userDetail.tabRecommendations')} />
           <Tab label={t('admin.userDetail.tabWatchHistory')} />
-          <Tab label={t('admin.userDetail.tabPlaylists')} />
-          <Tab label={t('admin.userDetail.tabDiagnostics')} />
           <Tab label={t('admin.userDetail.tabSettings')} />
         </Tabs>
 
@@ -953,18 +951,6 @@ export function UserDetailPage() {
           </TabPanel>
 
           <TabPanel value={tabValue} index={2}>
-            <Typography color="text.secondary">
-              {t('admin.userDetail.playlistsPlaceholder')}
-            </Typography>
-          </TabPanel>
-
-          <TabPanel value={tabValue} index={3}>
-            <Typography color="text.secondary">
-              {t('admin.userDetail.diagnosticsPlaceholder')}
-            </Typography>
-          </TabPanel>
-
-          <TabPanel value={tabValue} index={4}>
             <UserSettingsTab userId={user.id} user={user} />
           </TabPanel>
         </Box>

--- a/apps/web/src/pages/discovery/hooks/useDiscoveryData.ts
+++ b/apps/web/src/pages/discovery/hooks/useDiscoveryData.ts
@@ -259,14 +259,12 @@ export function useDiscoveryData(filters: DiscoveryFilterOptions = {}) {
     
     // Don't expand if already expanding, already attempted, or have enough candidates
     if (expandingRef.current) {
-      console.log('[Discovery] Already expanding, skipping')
       return null
     }
     if (currentCandidates.length >= EXPANSION_THRESHOLD) {
       return null
     }
     if (expansionAttemptedRef.current === expansionKey) {
-      console.log('[Discovery] Already attempted for this filter combination, skipping')
       return null
     }
 
@@ -278,8 +276,6 @@ export function useDiscoveryData(filters: DiscoveryFilterOptions = {}) {
     try {
       // Get existing TMDb IDs to exclude from expansion
       const existingTmdbIds = currentCandidates.map(c => c.tmdbId)
-
-      console.log('[Discovery] Expanding with filters:', { mediaType, filters, excludeCount: existingTmdbIds.length })
 
       const response = await fetch(`/api/discovery/${mediaType === 'movie' ? 'movies' : 'series'}/expand`, {
         method: 'POST',
@@ -304,10 +300,7 @@ export function useDiscoveryData(filters: DiscoveryFilterOptions = {}) {
       const data = await response.json()
       const newCandidates = data.candidates || []
 
-      console.log('[Discovery] Expand returned', newCandidates.length, 'candidates')
-
       if (newCandidates.length === 0) {
-        console.log('[Discovery] No new candidates found, expansion complete')
         return null
       }
 
@@ -344,13 +337,13 @@ export function useDiscoveryData(filters: DiscoveryFilterOptions = {}) {
      
   }, [filters, fetchSeerrStatus])
 
-  // Check if filters have changed
-  const filtersChanged = JSON.stringify(filters) !== JSON.stringify(filtersRef.current)
-  if (filtersChanged) {
-    filtersRef.current = filters
-    // Reset expansion tracking when filters change
-    expansionAttemptedRef.current = ''
-  }
+  useEffect(() => {
+    const filtersChanged = JSON.stringify(filters) !== JSON.stringify(filtersRef.current)
+    if (filtersChanged) {
+      filtersRef.current = filters
+      expansionAttemptedRef.current = ''
+    }
+  }, [filters])
 
   useEffect(() => {
     const load = async () => {
@@ -440,13 +433,11 @@ export function useDiscoveryData(filters: DiscoveryFilterOptions = {}) {
 
       // Check movies
       if (movieCandidates.length > 0 && movieCandidates.length < EXPANSION_THRESHOLD) {
-        console.log(`[Discovery] Movie count (${movieCandidates.length}) below threshold (${EXPANSION_THRESHOLD}), expanding...`)
         await expandDiscovery('movie', movieCandidates)
       }
 
       // Check series
       if (seriesCandidates.length > 0 && seriesCandidates.length < EXPANSION_THRESHOLD) {
-        console.log(`[Discovery] Series count (${seriesCandidates.length}) below threshold (${EXPANSION_THRESHOLD}), expanding...`)
         await expandDiscovery('series', seriesCandidates)
       }
     }

--- a/apps/web/src/pages/media-detail/components/MediaInfoCard.tsx
+++ b/apps/web/src/pages/media-detail/components/MediaInfoCard.tsx
@@ -163,26 +163,12 @@ function LetterboxdBadge({ score }: { score: number | string }) {
   )
 }
 
-// Helper to get actors from either movie or series
 function getActors(media: Media): Actor[] {
-  if (isSeries(media)) {
-    return media.actors || []
-  }
-  if (isMovie(media)) {
-    return media.actors || []
-  }
-  return []
+  return media.actors || []
 }
 
-// Helper to get studios
 function getStudios(media: Media): StudioItem[] {
-  if (isSeries(media)) {
-    return media.studios || []
-  }
-  if (isMovie(media)) {
-    return media.studios || []
-  }
-  return []
+  return media.studios || []
 }
 
 export function MediaInfoCard({ media, watchStats }: MediaInfoCardProps) {


### PR DESCRIPTION
## Summary
- Remove temporary discovery and person portrait debug tracing from web pages and hooks.
- Hide unfinished admin Playlists and Diagnostics tabs until they have real content.
- Move discovery filter reset work out of render and simplify redundant media info helpers.

## Test plan
- pnpm validate