### PR TITLE
refactor(web): share person portrait fallback logic

### DIFF
--- a/apps/web/src/hooks/usePersonPortrait.ts
+++ b/apps/web/src/hooks/usePersonPortrait.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getProxiedImageUrl } from '@aperture/ui'
+
+export type PersonPortraitPhase = 'media' | 'pending-tmdb' | 'tmdb' | 'none'
+
+interface UsePersonPortraitOptions {
+  personName: string
+  mediaImageUrl: string | null | undefined
+  tmdbImageUrl?: string | null
+  fetchTmdbFallback?: boolean
+}
+
+export function usePersonPortrait({
+  personName,
+  mediaImageUrl,
+  tmdbImageUrl,
+  fetchTmdbFallback = false,
+}: UsePersonPortraitOptions) {
+  const [phase, setPhase] = useState<PersonPortraitPhase>('media')
+  const [fetchedTmdbUrl, setFetchedTmdbUrl] = useState<string | null>(null)
+  const phaseRef = useRef(phase)
+  phaseRef.current = phase
+
+  useEffect(() => {
+    setPhase('media')
+    setFetchedTmdbUrl(null)
+  }, [personName, mediaImageUrl, tmdbImageUrl])
+
+  const resolvedTmdbUrl = tmdbImageUrl ?? fetchedTmdbUrl
+
+  const displaySrc = useMemo(() => {
+    if (phase === 'media' && mediaImageUrl) {
+      return getProxiedImageUrl(mediaImageUrl, '')
+    }
+    if (phase === 'tmdb' && resolvedTmdbUrl) {
+      return getProxiedImageUrl(resolvedTmdbUrl, '')
+    }
+    return undefined
+  }, [mediaImageUrl, phase, resolvedTmdbUrl])
+
+  const onImageError = useCallback(() => {
+    if (phaseRef.current === 'media') {
+      if (tmdbImageUrl) {
+        setPhase('tmdb')
+        return
+      }
+
+      if (fetchTmdbFallback) {
+        setPhase('pending-tmdb')
+        void fetch(
+          `/api/discover/person-profile?name=${encodeURIComponent(personName)}`,
+          { credentials: 'include' }
+        )
+          .then((r) => r.json())
+          .then((data: { imageUrl?: string | null }) => {
+            if (data?.imageUrl) {
+              setFetchedTmdbUrl(data.imageUrl)
+              setPhase('tmdb')
+            } else {
+              setPhase('none')
+            }
+          })
+          .catch(() => {
+            setPhase('none')
+          })
+        return
+      }
+    }
+
+    setPhase('none')
+  }, [fetchTmdbFallback, personName, tmdbImageUrl])
+
+  return { displaySrc, phase, onImageError }
+}

--- a/apps/web/src/pages/Browse.tsx
+++ b/apps/web/src/pages/Browse.tsx
@@ -32,10 +32,11 @@ import PersonIcon from '@mui/icons-material/Person'
 import VideoLibraryIcon from '@mui/icons-material/VideoLibrary'
 import GridViewIcon from '@mui/icons-material/GridView'
 import ViewListIcon from '@mui/icons-material/ViewList'
-import { MoviePoster, getProxiedImageUrl } from '@aperture/ui'
+import { MoviePoster } from '@aperture/ui'
 import { useUserRatings } from '../hooks/useUserRatings'
 import { useWatching } from '../hooks/useWatching'
 import { useViewMode } from '../hooks/useViewMode'
+import { usePersonPortrait } from '../hooks/usePersonPortrait'
 import {
   BrowseMovieListItem,
   BrowseSeriesListItem,
@@ -119,56 +120,6 @@ function personSubtitle(person: BrowsePerson, t: TFunction): string {
     : t('browse.personSubtitle.creditsOnly', { count: person.credits })
 }
 
-/** Media-server portrait first; on failure fetch TMDb profile URL (lazy). */
-function usePersonBrowsePortrait(personName: string) {
-  const raw = `/api/media/images/Persons/${encodeURIComponent(personName)}/Images/Primary`
-  const proxied = getProxiedImageUrl(raw, '')
-  const [phase, setPhase] = useState<'proxy' | 'pending-tmdb' | 'tmdb' | 'none'>('proxy')
-  const [tmdbUrl, setTmdbUrl] = useState<string | null>(null)
-  const phaseRef = useRef(phase)
-  phaseRef.current = phase
-
-  useEffect(() => {
-    setPhase('proxy')
-    setTmdbUrl(null)
-  }, [personName])
-
-  const displaySrc =
-    phase === 'proxy'
-      ? proxied
-      : phase === 'pending-tmdb'
-        ? undefined
-        : phase === 'tmdb' && tmdbUrl
-          ? getProxiedImageUrl(tmdbUrl, '')
-          : undefined
-
-  const onImageError = useCallback(() => {
-    if (phaseRef.current === 'proxy') {
-      setPhase('pending-tmdb')
-      void fetch(
-        `/api/discover/person-profile?name=${encodeURIComponent(personName)}`,
-        { credentials: 'include' }
-      )
-        .then((r) => r.json())
-        .then((data: { imageUrl?: string | null }) => {
-          if (data?.imageUrl) {
-            setTmdbUrl(data.imageUrl)
-            setPhase('tmdb')
-          } else {
-            setPhase('none')
-          }
-        })
-        .catch(() => {
-          setPhase('none')
-        })
-    } else {
-      setPhase('none')
-    }
-  }, [personName])
-
-  return { displaySrc, phase, onImageError }
-}
-
 function browseTabFromSearchParam(tab: string | null): number {
   if (tab === 'series') return 1
   if (tab === 'people') return 2
@@ -183,7 +134,11 @@ function BrowsePersonRow({
   onNavigate: () => void
 }) {
   const { t } = useTranslation()
-  const { displaySrc, phase, onImageError } = usePersonBrowsePortrait(person.name)
+  const { displaySrc, phase, onImageError } = usePersonPortrait({
+    personName: person.name,
+    mediaImageUrl: `/api/media/images/Persons/${encodeURIComponent(person.name)}/Images/Primary`,
+    fetchTmdbFallback: true,
+  })
   const subtitle = personSubtitle(person, t)
   const [avatarImgShown, setAvatarImgShown] = useState(false)
 
@@ -243,7 +198,11 @@ function BrowsePersonCard({
   onNavigate: () => void
 }) {
   const { t } = useTranslation()
-  const { displaySrc, phase, onImageError } = usePersonBrowsePortrait(person.name)
+  const { displaySrc, phase, onImageError } = usePersonPortrait({
+    personName: person.name,
+    mediaImageUrl: `/api/media/images/Persons/${encodeURIComponent(person.name)}/Images/Primary`,
+    fetchTmdbFallback: true,
+  })
   const subtitle = personSubtitle(person, t)
   const [cardImgShown, setCardImgShown] = useState(false)
 

--- a/apps/web/src/pages/PersonDetail.tsx
+++ b/apps/web/src/pages/PersonDetail.tsx
@@ -27,6 +27,7 @@ import {
 } from '@aperture/ui'
 import { useUserRatings } from '../hooks/useUserRatings'
 import { useWatching } from '../hooks/useWatching'
+import { usePersonPortrait } from '../hooks/usePersonPortrait'
 import { RotatingBackdrop } from '../components/RotatingBackdrop'
 import { MediaPosterCard } from '../components/MediaPosterCard'
 import { SeasonSelectModal, type SeasonInfo } from './discovery/components/SeasonSelectModal'
@@ -113,7 +114,6 @@ export function PersonDetailPage() {
   const [data, setData] = useState<PersonData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [avatarPhase, setAvatarPhase] = useState<'media' | 'tmdb' | 'initials'>('media')
   const [creditsGap, setCreditsGap] = useState<CreditsGapResponse | null>(null)
   const [creditsGapLoading, setCreditsGapLoading] = useState(false)
   const [seerrStatuses, setSeerrStatuses] = useState<
@@ -149,7 +149,6 @@ export function PersonDetailPage() {
       try {
         setLoading(true)
         setError(null)
-        setAvatarPhase('media')
         const response = await fetch(`/api/discover/person/${encodeURIComponent(name)}`, {
           credentials: 'include',
         })
@@ -219,22 +218,11 @@ export function PersonDetailPage() {
 
   const decodedName = useMemo(() => decodeURIComponent(name || ''), [name])
 
-  const proxiedImageUrl = useMemo(() => {
-    if (!data?.imageUrl) return null
-    return getProxiedImageUrl(data.imageUrl, '')
-  }, [data?.imageUrl])
-
-  const proxiedTmdbFallback = useMemo(() => {
-    if (!data?.tmdbFallbackImageUrl) return null
-    return getProxiedImageUrl(data.tmdbFallbackImageUrl, '')
-  }, [data?.tmdbFallbackImageUrl])
-
-  const avatarSrc = useMemo(() => {
-    if (!data) return undefined
-    if (avatarPhase === 'media') return proxiedImageUrl ?? undefined
-    if (avatarPhase === 'tmdb') return proxiedTmdbFallback ?? undefined
-    return undefined
-  }, [data, avatarPhase, proxiedImageUrl, proxiedTmdbFallback])
+  const { displaySrc: avatarSrc, onImageError: handleAvatarError } = usePersonPortrait({
+    personName: decodedName,
+    mediaImageUrl: data?.imageUrl,
+    tmdbImageUrl: data?.tmdbFallbackImageUrl,
+  })
 
   useEffect(() => {
     setAvatarImgVisible(false)
@@ -275,14 +263,6 @@ export function PersonDetailPage() {
         <Alert severity="error">{error || t('personDetail.notFound')}</Alert>
       </Box>
     )
-  }
-
-  const handleAvatarError = () => {
-    if (avatarPhase === 'media' && proxiedTmdbFallback) {
-      setAvatarPhase('tmdb')
-    } else {
-      setAvatarPhase('initials')
-    }
   }
 
   const markCreditsRowRequested = (tmdbId: number) => {


### PR DESCRIPTION
## Summary
- Extract shared person portrait fallback handling into `usePersonPortrait`.
- Reuse the hook from browse people cards/rows and the person detail header avatar.

## Test plan
- pnpm validate