### PR TITLE
refactor(web): split UserSettings into focused modules

### DIFF
--- a/apps/web/src/pages/UserSettings.tsx
+++ b/apps/web/src/pages/UserSettings.tsx
@@ -1,81 +1,59 @@
-import React, { useState, useEffect, useCallback } from 'react'
-import {
-  Box,
-  Typography,
-  Tabs,
-  Tab,
-  Paper,
-  Card,
-  CardContent,
-  TextField,
-  Button,
-  Alert,
-  CircularProgress,
-  FormControl,
-  Divider,
-  Avatar,
-  Switch,
-  FormControlLabel,
-  Grid,
-} from '@mui/material'
+import React, { useCallback, useEffect, useState } from 'react'
+import { Box, Grid, Paper, Tab, Tabs, Typography } from '@mui/material'
 import SettingsIcon from '@mui/icons-material/Settings'
 import PersonIcon from '@mui/icons-material/Person'
 import VideoLibraryIcon from '@mui/icons-material/VideoLibrary'
-import SaveIcon from '@mui/icons-material/Save'
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined'
 import FingerprintIcon from '@mui/icons-material/Fingerprint'
 import MovieIcon from '@mui/icons-material/Movie'
 import TvIcon from '@mui/icons-material/Tv'
 import TuneIcon from '@mui/icons-material/Tune'
-import TextFieldsIcon from '@mui/icons-material/TextFields'
 import { useSearchParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { useAuth } from '@/hooks/useAuth'
 import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { WatcherIdentitySection } from './UserSettings/WatcherIdentitySection'
 import { AlgorithmSettingsSection } from './UserSettings/AlgorithmSettingsSection'
 import { UserLanguagePreferencesCard } from './UserSettings/UserLanguagePreferencesCard'
-import { useTranslation } from 'react-i18next'
-
-interface TabPanelProps {
-  children?: React.ReactNode
-  index: number
-  value: number
-}
-
-function TabPanel({ children, value, index }: TabPanelProps) {
-  return (
-    <div role="tabpanel" hidden={value !== index}>
-      {value === index && <Box sx={{ pt: 3 }}>{children}</Box>}
-    </div>
-  )
-}
-
-const USER_SETTINGS_TAB_KEYS = ['profile', 'watcher', 'algorithm', 'preferences'] as const
-
-function userSettingsTabIndexFromParam(tab: string | null): number {
-  if (!tab) return 0
-  const idx = USER_SETTINGS_TAB_KEYS.indexOf(tab as (typeof USER_SETTINGS_TAB_KEYS)[number])
-  return idx >= 0 ? idx : 0
-}
-
-function userSettingsTabParamFromIndex(index: number): string {
-  return USER_SETTINGS_TAB_KEYS[index] ?? 'profile'
-}
-
-interface AiExplanationPreference {
-  overrideAllowed: boolean
-  userPreference: boolean | null
-  effectiveValue: boolean
-  globalEnabled: boolean
-  canOverride: boolean
-}
+import { UserProfileTab } from './UserSettings/UserProfileTab'
+import { AiLibraryNamesCard } from './UserSettings/AiLibraryNamesCard'
+import { AiExplanationPreferenceCard } from './UserSettings/AiExplanationPreferenceCard'
+import { SimilarityGraphPrefsCard } from './UserSettings/SimilarityGraphPrefsCard'
+import { TraktIntegrationCard } from './UserSettings/TraktIntegrationCard'
+import { useTraktIntegration } from './UserSettings/hooks/useTraktIntegration'
+import { TabPanel } from './UserSettings/TabPanel'
+import {
+  userSettingsTabIndexFromParam,
+  userSettingsTabParamFromIndex,
+} from './UserSettings/tabHelpers'
 
 export function UserSettingsPage() {
   const { t } = useTranslation()
   const { user } = useAuth()
   const [searchParams, setSearchParams] = useSearchParams()
   const [tabValue, setTabValue] = useState(() => userSettingsTabIndexFromParam(searchParams.get('tab')))
+  const [identityMediaType, setIdentityMediaType] = useState<'movie' | 'series'>('movie')
+
+  const [email, setEmail] = useState('')
+  const [originalEmail, setOriginalEmail] = useState('')
+  const [emailLocked, setEmailLocked] = useState(false)
+  const [emailNotificationsEnabled, setEmailNotificationsEnabled] = useState(true)
+  const [loadingEmail, setLoadingEmail] = useState(false)
+  const [savingEmail, setSavingEmail] = useState(false)
+  const [emailSuccess, setEmailSuccess] = useState<string | null>(null)
+  const [emailError, setEmailError] = useState<string | null>(null)
+
+  const {
+    status: traktStatus,
+    loading: loadingTrakt,
+    syncing: syncingTrakt,
+    message: traktMessage,
+    setMessage: setTraktMessage,
+    fetchStatus: fetchTraktStatus,
+    connect: connectTrakt,
+    disconnect: disconnectTrakt,
+    syncRatings: syncTraktRatings,
+    handleCallbackFromUrl: handleTraktCallbackFromUrl,
+  } = useTraktIntegration()
 
   useEffect(() => {
     setTabValue(userSettingsTabIndexFromParam(searchParams.get('tab')))
@@ -93,320 +71,45 @@ export function UserSettingsPage() {
     )
   }
 
-  const [identityMediaType, setIdentityMediaType] = useState<'movie' | 'series'>('movie')
-
-  // User settings state
-  const [defaultLibraryPrefix, setDefaultLibraryPrefix] = useState<string>('AI Picks - ')
-  const [loadingUserSettings, setLoadingUserSettings] = useState(false)
-  const [savingUserSettings, setSavingUserSettings] = useState(false)
-  const [userSettingsError, setUserSettingsError] = useState<string | null>(null)
-  const [userSettingsSuccess, setUserSettingsSuccess] = useState<string | null>(null)
-  const [moviesLibraryName, setMoviesLibraryName] = useState<string>('')
-  const [seriesLibraryName, setSeriesLibraryName] = useState<string>('')
-
-  // AI explanation preference state
-  const [aiExplanationPref, setAiExplanationPref] = useState<AiExplanationPreference | null>(null)
-  const [loadingAiPref, setLoadingAiPref] = useState(false)
-  const [savingAiPref, setSavingAiPref] = useState(false)
-  const [aiPrefError, setAiPrefError] = useState<string | null>(null)
-  const [aiPrefSuccess, setAiPrefSuccess] = useState<string | null>(null)
-
-  // Similarity graph preferences state
-  const [similarityFullFranchise, setSimilarityFullFranchise] = useState(false)
-  const [similarityHideWatched, setSimilarityHideWatched] = useState(true) // Default ON
-  const [loadingSimilarityPrefs, setLoadingSimilarityPrefs] = useState(false)
-  const [savingSimilarityPrefs, setSavingSimilarityPrefs] = useState(false)
-  const [similarityPrefsSuccess, setSimilarityPrefsSuccess] = useState<string | null>(null)
-
-  // Trakt integration state
-  const [traktStatus, setTraktStatus] = useState<{
-    traktConfigured: boolean
-    connected: boolean
-    username: string | null
-    syncedAt: string | null
-  } | null>(null)
-  const [loadingTrakt, setLoadingTrakt] = useState(false)
-  const [syncingTrakt, setSyncingTrakt] = useState(false)
-  const [traktMessage, setTraktMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
-
-  // Email settings state
-  const [email, setEmail] = useState<string>('')
-  const [originalEmail, setOriginalEmail] = useState<string>('') // Track original to detect changes
-  const [emailLocked, setEmailLocked] = useState(false)
-  const [emailNotificationsEnabled, setEmailNotificationsEnabled] = useState(true)
-  const [loadingEmail, setLoadingEmail] = useState(false)
-  const [savingEmail, setSavingEmail] = useState(false)
-  const [emailSuccess, setEmailSuccess] = useState<string | null>(null)
-
-  const fetchUserSettings = useCallback(async () => {
-    setLoadingUserSettings(true)
-    setUserSettingsError(null)
-    try {
-      const response = await fetch('/api/settings/user', { credentials: 'include' })
-      if (response.ok) {
-        const data = await response.json()
-        setDefaultLibraryPrefix(data.defaults?.libraryNamePrefix || 'AI Picks - ')
-        setMoviesLibraryName(data.settings?.libraryName || '')
-        setSeriesLibraryName(data.settings?.seriesLibraryName || '')
-      } else {
-        const err = await response.json()
-        setUserSettingsError(err.error || t('userSettings.errLoadUserSettings'))
-      }
-    } catch {
-      setUserSettingsError(t('userSettings.errConnectServer'))
-    } finally {
-      setLoadingUserSettings(false)
-    }
-  }, [t])
-
-  const saveUserSettings = async () => {
-    setSavingUserSettings(true)
-    setUserSettingsError(null)
-    setUserSettingsSuccess(null)
-    try {
-      const response = await fetch('/api/settings/user', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          libraryName: moviesLibraryName.trim() || null,
-          seriesLibraryName: seriesLibraryName.trim() || null,
-        }),
-      })
-      if (response.ok) {
-        setUserSettingsSuccess(t('userSettings.libraryNamesSaved'))
-        setTimeout(() => setUserSettingsSuccess(null), 5000)
-      } else {
-        const err = await response.json()
-        setUserSettingsError(err.error || t('userSettings.errSaveSettings'))
-      }
-    } catch {
-      setUserSettingsError(t('userSettings.errConnectServer'))
-    } finally {
-      setSavingUserSettings(false)
-    }
-  }
-
-  const fetchAiExplanationPref = useCallback(async () => {
-    setLoadingAiPref(true)
-    try {
-      const response = await fetch('/api/settings/user/ai-explanation', { credentials: 'include' })
-      if (response.ok) {
-        const data = await response.json()
-        setAiExplanationPref(data)
-      }
-    } catch {
-      // Silently fail - this is optional functionality
-    } finally {
-      setLoadingAiPref(false)
-    }
-  }, [])
-
-  const saveAiExplanationPref = async (enabled: boolean | null) => {
-    if (!aiExplanationPref) return
-    setSavingAiPref(true)
-    setAiPrefError(null)
-    setAiPrefSuccess(null)
-    try {
-      const response = await fetch('/api/settings/user/ai-explanation', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ enabled }),
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setAiExplanationPref({
-          ...aiExplanationPref,
-          userPreference: data.userPreference,
-          effectiveValue: data.effectiveValue,
-        })
-        setAiPrefSuccess(data.message)
-        setTimeout(() => setAiPrefSuccess(null), 5000)
-      } else {
-        const err = await response.json()
-        setAiPrefError(err.error || t('userSettings.errSavePreference'))
-      }
-    } catch {
-      setAiPrefError(t('userSettings.errConnectServer'))
-    } finally {
-      setSavingAiPref(false)
-    }
-  }
-
-  const fetchSimilarityPrefs = useCallback(async () => {
-    setLoadingSimilarityPrefs(true)
-    try {
-      const response = await fetch('/api/settings/user/similarity-prefs', { credentials: 'include' })
-      if (response.ok) {
-        const data = await response.json()
-        setSimilarityFullFranchise(data.fullFranchiseMode ?? false)
-        setSimilarityHideWatched(data.hideWatched ?? true)
-      }
-    } catch {
-      // Silently fail - use defaults
-    } finally {
-      setLoadingSimilarityPrefs(false)
-    }
-  }, [])
-
-  const saveSimilarityPref = async (key: 'fullFranchiseMode' | 'hideWatched', value: boolean) => {
-    setSavingSimilarityPrefs(true)
-    setSimilarityPrefsSuccess(null)
-    try {
-      const response = await fetch('/api/settings/user/similarity-prefs', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ [key]: value }),
-      })
-      if (response.ok) {
-        if (key === 'fullFranchiseMode') {
-          setSimilarityFullFranchise(value)
-        } else {
-          setSimilarityHideWatched(value)
-        }
-        setSimilarityPrefsSuccess(t('userSettings.preferenceSaved'))
-        setTimeout(() => setSimilarityPrefsSuccess(null), 3000)
-      }
-    } catch {
-      // Silently fail
-    } finally {
-      setSavingSimilarityPrefs(false)
-    }
-  }
-
-  const fetchTraktStatus = useCallback(async () => {
-    setLoadingTrakt(true)
-    try {
-      const response = await fetch('/api/trakt/status', { credentials: 'include' })
-      if (response.ok) {
-        const data = await response.json()
-        setTraktStatus(data)
-      }
-    } catch {
-      // Silently fail
-    } finally {
-      setLoadingTrakt(false)
-    }
-  }, [])
-
-  const connectTrakt = async () => {
-    try {
-      const response = await fetch('/api/trakt/auth-url', { credentials: 'include' })
-      if (response.ok) {
-        const data = await response.json()
-        window.location.href = data.authUrl
-      } else {
-        const err = await response.json()
-        setTraktMessage({ type: 'error', text: err.error || t('userSettings.traktErrStart') })
-      }
-    } catch {
-      setTraktMessage({ type: 'error', text: t('userSettings.errConnectServer') })
-    }
-  }
-
-  const disconnectTrakt = async () => {
-    try {
-      const response = await fetch('/api/trakt/disconnect', {
-        method: 'POST',
-        credentials: 'include',
-      })
-      if (response.ok) {
-        setTraktStatus(prev => prev ? { ...prev, connected: false, username: null, syncedAt: null } : null)
-        setTraktMessage({ type: 'success', text: t('userSettings.traktDisconnected') })
-        setTimeout(() => setTraktMessage(null), 3000)
-      }
-    } catch {
-      setTraktMessage({ type: 'error', text: t('userSettings.traktErrDisconnect') })
-    }
-  }
-
-  const syncTraktRatings = async () => {
-    setSyncingTrakt(true)
-    setTraktMessage(null)
-    try {
-      const response = await fetch('/api/trakt/sync', {
-        method: 'POST',
-        credentials: 'include',
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setTraktMessage({ type: 'success', text: data.message })
-        fetchTraktStatus()
-      } else {
-        const err = await response.json()
-        setTraktMessage({ type: 'error', text: err.error || t('userSettings.traktErrSync') })
-      }
-    } catch {
-      setTraktMessage({ type: 'error', text: t('userSettings.errConnectServer') })
-    } finally {
-      setSyncingTrakt(false)
-    }
-  }
-
   const fetchEmailSettings = useCallback(async () => {
     if (!user?.id) return
     setLoadingEmail(true)
     try {
       const response = await fetch(`/api/users/${user.id}/email-settings`, { credentials: 'include' })
       if (response.ok) {
-        const data = await response.json()
+        const data = (await response.json()) as {
+          email?: string
+          emailLocked?: boolean
+          emailNotificationsEnabled?: boolean
+        }
         const emailValue = data.email || ''
         setEmail(emailValue)
-        setOriginalEmail(emailValue) // Track original value
+        setOriginalEmail(emailValue)
         setEmailLocked(data.emailLocked || false)
         setEmailNotificationsEnabled(data.emailNotificationsEnabled ?? true)
       }
     } catch {
-      // Silently fail
+      // Optional load failures may degrade gracefully
     } finally {
       setLoadingEmail(false)
     }
   }, [user?.id])
 
   useEffect(() => {
-    fetchUserSettings()
-    fetchAiExplanationPref()
-    fetchSimilarityPrefs()
-    fetchTraktStatus()
-    fetchEmailSettings()
-
-    // Check for Trakt callback params
-    const params = new URLSearchParams(window.location.hash.split('?')[1] || '')
-    if (params.get('trakt') === 'success') {
-      const username = params.get('username')
-      setTraktMessage({
-        type: 'success',
-        text: t('userSettings.traktSuccessConnect', { username: username ?? '' }),
-      })
-      fetchTraktStatus()
-      // Clean URL
-      window.history.replaceState(null, '', window.location.pathname + '#/settings')
-    } else if (params.get('trakt') === 'error') {
-      const message = params.get('message') || t('userSettings.traktErrUnknown')
-      setTraktMessage({ type: 'error', text: t('userSettings.traktFailConnect', { message }) })
-      // Clean URL
-      window.history.replaceState(null, '', window.location.pathname + '#/settings')
-    }
-  }, [
-    t,
-    fetchUserSettings,
-    fetchAiExplanationPref,
-    fetchSimilarityPrefs,
-    fetchTraktStatus,
-    fetchEmailSettings,
-  ])
+    void fetchEmailSettings()
+    void fetchTraktStatus()
+    handleTraktCallbackFromUrl()
+  }, [fetchEmailSettings, fetchTraktStatus, handleTraktCallbackFromUrl])
 
   const saveEmailSettings = async (newEmail?: string, newNotificationsEnabled?: boolean) => {
     if (!user?.id) return
-    
-    // Skip save if email hasn't changed
+
     if (newEmail !== undefined && newEmail.trim() === originalEmail) {
       return
     }
-    
+
     setSavingEmail(true)
+    setEmailError(null)
     try {
       const body: { email?: string | null; emailNotificationsEnabled?: boolean } = {}
       if (newEmail !== undefined) {
@@ -423,28 +126,36 @@ export function UserSettingsPage() {
         body: JSON.stringify(body),
       })
       if (response.ok) {
-        const data = await response.json()
+        const data = (await response.json()) as {
+          email?: string
+          emailLocked?: boolean
+          emailNotificationsEnabled?: boolean
+        }
         const emailValue = data.email || ''
         setEmail(emailValue)
-        setOriginalEmail(emailValue) // Update original after successful save
+        setOriginalEmail(emailValue)
         setEmailLocked(data.emailLocked || false)
         setEmailNotificationsEnabled(data.emailNotificationsEnabled ?? true)
         setEmailSuccess(t('userSettings.emailSettingsSaved'))
-        setTimeout(() => setEmailSuccess(null), 3000)
+        window.setTimeout(() => setEmailSuccess(null), 3000)
+      } else {
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setEmailError(err.error || t('userSettings.errSaveSettings'))
       }
     } catch {
-      // Silently fail
+      setEmailError(t('userSettings.errConnectServer'))
     } finally {
       setSavingEmail(false)
     }
   }
 
+  const identityAccentColor = identityMediaType === 'movie' ? '#6366f1' : '#ec4899'
+
   return (
     <Box>
-      {/* Header */}
       <Box sx={{ mb: 3 }}>
         <Breadcrumbs />
-        
+
         <Box display="flex" alignItems="center" gap={2} mb={1}>
           <SettingsIcon sx={{ color: 'primary.main', fontSize: 32 }} />
           <Typography variant="h4" fontWeight={700}>
@@ -456,14 +167,7 @@ export function UserSettingsPage() {
         </Typography>
       </Box>
 
-      {/* Tabs */}
-      <Paper
-        sx={{
-          backgroundColor: 'background.paper',
-          borderRadius: 2,
-        }}
-        elevation={0}
-      >
+      <Paper sx={{ backgroundColor: 'background.paper', borderRadius: 2 }} elevation={0}>
         <Tabs
           value={tabValue}
           onChange={handleMainTabChange}
@@ -486,538 +190,84 @@ export function UserSettingsPage() {
         </Tabs>
 
         <Box sx={{ p: 3 }}>
-          {/* Profile Tab */}
           <TabPanel value={tabValue} index={0}>
-            <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, maxWidth: 600 }}>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={3} mb={4}>
-                  <Avatar
-                    src={user?.avatarUrl || undefined}
-                    sx={{
-                      width: 72,
-                      height: 72,
-                      bgcolor: 'primary.main',
-                      fontSize: '1.75rem',
-                    }}
-                  >
-                    {user?.username?.[0]?.toUpperCase() || 'U'}
-                  </Avatar>
-                  <Box>
-                    <Typography variant="h6" fontWeight={600}>
-                      {user?.displayName || user?.username}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {user?.isAdmin ? t('userSettings.roleAdmin') : t('userSettings.roleUser')} • {user?.provider ? user.provider.charAt(0).toUpperCase() + user.provider.slice(1) : ''}
-                    </Typography>
-                  </Box>
-                </Box>
-
-                <TextField
-                  label={t('login.username')}
-                  value={user?.username || ''}
-                  fullWidth
-                  margin="normal"
-                  disabled
-                  size="small"
-                />
-
-                <TextField
-                  label={t('userSettings.displayName')}
-                  value={user?.displayName || user?.username || ''}
-                  fullWidth
-                  margin="normal"
-                  disabled
-                  size="small"
-                />
-
-                <TextField
-                  label={t('userSettings.mediaServer')}
-                  value={user?.provider ? user.provider.charAt(0).toUpperCase() + user.provider.slice(1) : ''}
-                  fullWidth
-                  margin="normal"
-                  disabled
-                  size="small"
-                />
-
-                <TextField
-                  label={t('userSettings.roleField')}
-                  value={user?.isAdmin ? t('userSettings.roleAdmin') : t('userSettings.roleUser')}
-                  fullWidth
-                  margin="normal"
-                  disabled
-                  size="small"
-                />
-
-                <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
-                  {t('userSettings.profileSyncedCaption')}
-                </Typography>
-
-                <Divider sx={{ my: 3 }} />
-
-                {/* Email Section */}
-                <Typography variant="subtitle1" fontWeight={600} gutterBottom>
-                  {t('userSettings.emailSectionTitle')}
-                </Typography>
-
-                {emailSuccess && (
-                  <Alert severity="success" sx={{ mb: 2 }} onClose={() => setEmailSuccess(null)}>
-                    {emailSuccess}
-                  </Alert>
-                )}
-
-                {loadingEmail ? (
-                  <Box display="flex" justifyContent="center" py={2}>
-                    <CircularProgress size={24} />
-                  </Box>
-                ) : (
-                  <>
-                    <TextField
-                      label={t('userSettings.emailAddress')}
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      fullWidth
-                      margin="normal"
-                      size="small"
-                      placeholder={t('userSettings.emailPlaceholder')}
-                      helperText={
-                        emailLocked ? t('userSettings.emailHelperCustom') : t('userSettings.emailHelperSynced')
-                      }
-                      InputProps={{
-                        endAdornment: savingEmail ? (
-                          <CircularProgress size={16} />
-                        ) : null,
-                      }}
-                      onBlur={() => saveEmailSettings(email)}
-                    />
-
-                    <FormControlLabel
-                      control={
-                        <Switch
-                          checked={emailNotificationsEnabled}
-                          onChange={(e) => {
-                            setEmailNotificationsEnabled(e.target.checked)
-                            saveEmailSettings(undefined, e.target.checked)
-                          }}
-                          disabled={savingEmail}
-                        />
-                      }
-                      label={
-                        <Box>
-                          <Typography variant="body2">
-                            {t('userSettings.emailNotificationsTitle')}
-                          </Typography>
-                          <Typography variant="caption" color="text.secondary">
-                            {t('userSettings.emailNotificationsSubtitle')}
-                          </Typography>
-                        </Box>
-                      }
-                      sx={{ mt: 1, alignItems: 'flex-start' }}
-                    />
-                  </>
-                )}
-              </CardContent>
-            </Card>
+            <UserProfileTab
+              user={user}
+              email={email}
+              originalEmail={originalEmail}
+              emailLocked={emailLocked}
+              emailNotificationsEnabled={emailNotificationsEnabled}
+              loadingEmail={loadingEmail}
+              savingEmail={savingEmail}
+              emailSuccess={emailSuccess}
+              emailError={emailError}
+              onEmailChange={setEmail}
+              onEmailBlur={() => void saveEmailSettings(email)}
+              onNotificationsChange={(enabled) => {
+                setEmailNotificationsEnabled(enabled)
+                void saveEmailSettings(undefined, enabled)
+              }}
+              onDismissSuccess={() => setEmailSuccess(null)}
+              onDismissEmailError={() => setEmailError(null)}
+            />
           </TabPanel>
 
-          {/* Watcher Identity Tab */}
           <TabPanel value={tabValue} index={1}>
-            {/* Sub-tabs for Movies/Series */}
-            {(() => {
-              const identityAccentColor = identityMediaType === 'movie' ? '#6366f1' : '#ec4899'
-              return (
-                <Tabs
-                  value={identityMediaType}
-                  onChange={(_, value) => setIdentityMediaType(value)}
-                  sx={{
-                    mb: 3,
-                    borderBottom: 1,
-                    borderColor: 'divider',
-                    '& .MuiTab-root': {
-                      minHeight: 48,
-                      textTransform: 'none',
-                    },
-                    '& .MuiTabs-indicator': {
-                      backgroundColor: identityAccentColor,
-                    },
-                    '& .Mui-selected': {
-                      color: `${identityAccentColor} !important`,
-                    },
-                  }}
-                >
-                  <Tab icon={<MovieIcon />} label={t('userSettings.identitySubtabMovies')} value="movie" iconPosition="start" />
-                  <Tab icon={<TvIcon />} label={t('userSettings.identitySubtabSeries')} value="series" iconPosition="start" />
-                </Tabs>
-              )
-            })()}
-
-            {/* Unified Watcher Identity Section */}
+            <Tabs
+              value={identityMediaType}
+              onChange={(_, value: 'movie' | 'series') => setIdentityMediaType(value)}
+              sx={{
+                mb: 3,
+                borderBottom: 1,
+                borderColor: 'divider',
+                '& .MuiTab-root': {
+                  minHeight: 48,
+                  textTransform: 'none',
+                },
+                '& .MuiTabs-indicator': {
+                  backgroundColor: identityAccentColor,
+                },
+                '& .Mui-selected': {
+                  color: `${identityAccentColor} !important`,
+                },
+              }}
+            >
+              <Tab icon={<MovieIcon />} label={t('userSettings.identitySubtabMovies')} value="movie" iconPosition="start" />
+              <Tab icon={<TvIcon />} label={t('userSettings.identitySubtabSeries')} value="series" iconPosition="start" />
+            </Tabs>
             <WatcherIdentitySection mediaType={identityMediaType} />
           </TabPanel>
 
-          {/* AI Algorithm Tab */}
           <TabPanel value={tabValue} index={2}>
             {user && <AlgorithmSettingsSection userId={user.id} />}
           </TabPanel>
 
-          {/* Preferences Tab */}
           <TabPanel value={tabValue} index={3}>
             <Grid container spacing={3}>
               <Grid item xs={12} lg={6}>
                 <UserLanguagePreferencesCard />
               </Grid>
-              {/* AI Library Names */}
               <Grid item xs={12} lg={6}>
-                <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
-                  <CardContent>
-                    <Box display="flex" alignItems="center" gap={1} mb={1}>
-                      <TextFieldsIcon color="primary" />
-                      <Typography variant="h6">{t('userSettings.aiLibraryNamesTitle')}</Typography>
-                    </Box>
-                    <Typography variant="body2" color="text.secondary" mb={3}>
-                      {t('userSettings.aiLibraryNamesSubtitle')}
-                    </Typography>
-
-                    {userSettingsError && (
-                      <Alert severity="error" sx={{ mb: 2 }} onClose={() => setUserSettingsError(null)}>
-                        {userSettingsError}
-                      </Alert>
-                    )}
-
-                    {userSettingsSuccess && (
-                      <Alert severity="success" sx={{ mb: 2 }} onClose={() => setUserSettingsSuccess(null)}>
-                        {userSettingsSuccess}
-                      </Alert>
-                    )}
-
-                    {loadingUserSettings ? (
-                      <Box display="flex" justifyContent="center" py={4}>
-                        <CircularProgress />
-                      </Box>
-                    ) : (
-                      <>
-                        <FormControl fullWidth sx={{ mb: 3 }}>
-                          <Typography variant="body2" fontWeight={500} gutterBottom>
-                            {t('userSettings.moviesLibraryNameLabel')}
-                          </Typography>
-                          <TextField
-                            placeholder={`${defaultLibraryPrefix}${user?.displayName || user?.username || 'User'} - Movies`}
-                            value={moviesLibraryName}
-                            onChange={(e) => setMoviesLibraryName(e.target.value)}
-                            size="small"
-                            fullWidth
-                            inputProps={{ maxLength: 100 }}
-                            helperText={
-                              moviesLibraryName
-                                ? t('userSettings.libraryHelperNamedMovies', { name: moviesLibraryName })
-                                : t('userSettings.libraryHelperEmpty')
-                            }
-                          />
-                        </FormControl>
-
-                        <FormControl fullWidth sx={{ mb: 3 }}>
-                          <Typography variant="body2" fontWeight={500} gutterBottom>
-                            {t('userSettings.seriesLibraryNameLabel')}
-                          </Typography>
-                          <TextField
-                            placeholder={`${defaultLibraryPrefix}${user?.displayName || user?.username || 'User'} - TV Series`}
-                            value={seriesLibraryName}
-                            onChange={(e) => setSeriesLibraryName(e.target.value)}
-                            size="small"
-                            fullWidth
-                            inputProps={{ maxLength: 100 }}
-                            helperText={
-                              seriesLibraryName
-                                ? t('userSettings.libraryHelperNamedSeries', { name: seriesLibraryName })
-                                : t('userSettings.libraryHelperEmpty')
-                            }
-                          />
-                        </FormControl>
-
-                        <Box display="flex" gap={1}>
-                          <Button
-                            variant="contained"
-                            startIcon={savingUserSettings ? <CircularProgress size={16} /> : <SaveIcon />}
-                            onClick={saveUserSettings}
-                            disabled={savingUserSettings}
-                            size="small"
-                          >
-                            {savingUserSettings ? t('userSettings.saving') : t('common.save')}
-                          </Button>
-                          {(moviesLibraryName || seriesLibraryName) && (
-                            <Button
-                              variant="outlined"
-                              onClick={() => {
-                                setMoviesLibraryName('')
-                                setSeriesLibraryName('')
-                              }}
-                              disabled={savingUserSettings}
-                              size="small"
-                            >
-                              {t('userSettings.resetToDefaults')}
-                            </Button>
-                          )}
-                        </Box>
-
-                        <Divider sx={{ my: 3 }} />
-
-                        <Typography variant="caption" color="text.secondary">
-                          {t('userSettings.aiLibraryFooter')}
-                        </Typography>
-                      </>
-                    )}
-                  </CardContent>
-                </Card>
+                <AiLibraryNamesCard user={user} />
               </Grid>
-
-              {/* AI Explanation Preference - only show if user can override */}
-              {aiExplanationPref?.canOverride && (
-                <Grid item xs={12} lg={6}>
-                  <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
-                    <CardContent>
-                      <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <AutoAwesomeIcon color="primary" />
-                        {t('userSettings.aiExplanationTitle')}
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary" mb={3}>
-                        {t('userSettings.aiExplanationSubtitle')}
-                      </Typography>
-
-                      {aiPrefError && (
-                        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setAiPrefError(null)}>
-                          {aiPrefError}
-                        </Alert>
-                      )}
-
-                      {aiPrefSuccess && (
-                        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setAiPrefSuccess(null)}>
-                          {aiPrefSuccess}
-                        </Alert>
-                      )}
-
-                      {loadingAiPref ? (
-                        <Box display="flex" justifyContent="center" py={4}>
-                          <CircularProgress />
-                        </Box>
-                      ) : (
-                        <>
-                          <FormControlLabel
-                            control={
-                              <Switch
-                                checked={aiExplanationPref.userPreference ?? aiExplanationPref.globalEnabled}
-                                onChange={(e) => saveAiExplanationPref(e.target.checked)}
-                                disabled={savingAiPref}
-                              />
-                            }
-                            label={
-                              <Box>
-                                <Typography variant="body1" fontWeight="medium">
-                                  {t('userSettings.aiExplanationIncludeTitle')}
-                                </Typography>
-                                <Typography variant="body2" color="text.secondary">
-                                  {t('userSettings.aiExplanationIncludeBody')}
-                                </Typography>
-                              </Box>
-                            }
-                            sx={{ alignItems: 'flex-start', ml: 0, mb: 2 }}
-                          />
-
-                          {aiExplanationPref.userPreference !== null && (
-                            <Button
-                              variant="outlined"
-                              size="small"
-                              onClick={() => saveAiExplanationPref(null)}
-                              disabled={savingAiPref}
-                            >
-                              {t('userSettings.aiExplanationReset', {
-                                state: aiExplanationPref.globalEnabled
-                                  ? t('userSettings.stateEnabled')
-                                  : t('userSettings.stateDisabled'),
-                              })}
-                            </Button>
-                          )}
-
-                          <Divider sx={{ my: 3 }} />
-
-                          <Typography variant="caption" color="text.secondary">
-                            {t('userSettings.aiExplanationFooter')}
-                          </Typography>
-                        </>
-                      )}
-                    </CardContent>
-                  </Card>
-                </Grid>
-              )}
-
-              {/* Similarity Graph Preferences */}
               <Grid item xs={12} lg={6}>
-                <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
-                  <CardContent>
-                    <Box display="flex" alignItems="center" gap={1} mb={1}>
-                      <HubOutlinedIcon color="primary" />
-                      <Typography variant="h6">
-                        {t('userSettings.similarityGraphPrefsTitle')}
-                      </Typography>
-                    </Box>
-                    <Typography variant="body2" color="text.secondary" mb={3}>
-                      {t('userSettings.similarityGraphPrefsSubtitle')}
-                    </Typography>
-
-                    {similarityPrefsSuccess && (
-                      <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSimilarityPrefsSuccess(null)}>
-                        {similarityPrefsSuccess}
-                      </Alert>
-                    )}
-
-                    {loadingSimilarityPrefs ? (
-                      <Box display="flex" justifyContent="center" py={4}>
-                        <CircularProgress />
-                      </Box>
-                    ) : (
-                      <>
-                        <FormControlLabel
-                          control={
-                            <Switch
-                              checked={similarityHideWatched}
-                              onChange={(e) => saveSimilarityPref('hideWatched', e.target.checked)}
-                              disabled={savingSimilarityPrefs}
-                            />
-                          }
-                          label={
-                            <Box>
-                              <Typography variant="body1" fontWeight="medium">
-                                {t('userSettings.hideWatchedTitle')}
-                              </Typography>
-                              <Typography variant="body2" color="text.secondary">
-                                {similarityHideWatched
-                                  ? t('userSettings.hideWatchedOn')
-                                  : t('userSettings.hideWatchedOff')}
-                              </Typography>
-                            </Box>
-                          }
-                          sx={{ alignItems: 'flex-start', ml: 0, mb: 2 }}
-                        />
-
-                        <FormControlLabel
-                          control={
-                            <Switch
-                              checked={similarityFullFranchise}
-                              onChange={(e) => saveSimilarityPref('fullFranchiseMode', e.target.checked)}
-                              disabled={savingSimilarityPrefs}
-                            />
-                          }
-                          label={
-                            <Box>
-                              <Typography variant="body1" fontWeight="medium">
-                                {t('userSettings.fullFranchiseTitle')}
-                              </Typography>
-                              <Typography variant="body2" color="text.secondary">
-                                {similarityFullFranchise
-                                  ? t('userSettings.fullFranchiseOn')
-                                  : t('userSettings.fullFranchiseOff')}
-                              </Typography>
-                            </Box>
-                          }
-                          sx={{ alignItems: 'flex-start', ml: 0 }}
-                        />
-
-                        <Divider sx={{ my: 3 }} />
-
-                        <Typography variant="caption" color="text.secondary">
-                          {t('userSettings.similarityGraphFooter')}
-                        </Typography>
-                      </>
-                    )}
-                  </CardContent>
-                </Card>
+                <AiExplanationPreferenceCard />
               </Grid>
-
-              {/* Trakt Integration */}
-              {traktStatus?.traktConfigured && (
-                <Grid item xs={12} lg={6}>
-                  <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
-                <CardContent>
-                  <Box display="flex" alignItems="center" gap={1} mb={1}>
-                    <Box
-                      component="img"
-                      src="/trakt.svg"
-                      alt={t('userSettings.traktAlt')}
-                      sx={{ width: 28, height: 28, filter: 'brightness(0) invert(1)' }}
-                    />
-                    <Typography variant="h6">
-                      {t('userSettings.traktTitle')}
-                    </Typography>
-                  </Box>
-                  <Typography variant="body2" color="text.secondary" mb={3}>
-                    {t('userSettings.traktSubtitle')}
-                  </Typography>
-
-                  {traktMessage && (
-                    <Alert severity={traktMessage.type} sx={{ mb: 2 }} onClose={() => setTraktMessage(null)}>
-                      {traktMessage.text}
-                    </Alert>
-                  )}
-
-                  {loadingTrakt ? (
-                    <Box display="flex" justifyContent="center" py={4}>
-                      <CircularProgress />
-                    </Box>
-                  ) : traktStatus.connected ? (
-                    <>
-                      <Box sx={{ bgcolor: 'action.hover', p: 2, borderRadius: 1, mb: 2 }}>
-                        <Typography variant="body2" fontWeight={500}>
-                          {t('userSettings.traktConnectedAs', { username: traktStatus.username ?? '' })}
-                        </Typography>
-                        {traktStatus.syncedAt && (
-                          <Typography variant="caption" color="text.secondary">
-                            {t('userSettings.traktLastSynced', {
-                              when: new Date(traktStatus.syncedAt).toLocaleString(),
-                            })}
-                          </Typography>
-                        )}
-                      </Box>
-
-                      <Box display="flex" gap={1}>
-                        <Button
-                          variant="contained"
-                          onClick={syncTraktRatings}
-                          disabled={syncingTrakt}
-                          size="small"
-                        >
-                          {syncingTrakt ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null}
-                          {syncingTrakt ? t('userSettings.traktSyncing') : t('userSettings.traktSyncRatings')}
-                        </Button>
-                        <Button
-                          variant="outlined"
-                          color="error"
-                          onClick={disconnectTrakt}
-                          size="small"
-                        >
-                          {t('userSettings.traktDisconnect')}
-                        </Button>
-                      </Box>
-                    </>
-                  ) : (
-                    <Button
-                      variant="contained"
-                      onClick={connectTrakt}
-                      sx={{
-                        bgcolor: '#ed1c24',
-                        '&:hover': { bgcolor: '#c9171d' },
-                      }}
-                    >
-                      {t('userSettings.traktConnect')}
-                    </Button>
-                  )}
-
-                    <Divider sx={{ my: 3 }} />
-
-                    <Typography variant="caption" color="text.secondary">
-                      {t('userSettings.traktFooter')}
-                    </Typography>
-                  </CardContent>
-                </Card>
+              <Grid item xs={12} lg={6}>
+                <SimilarityGraphPrefsCard />
               </Grid>
-              )}
+              <Grid item xs={12} lg={6}>
+                <TraktIntegrationCard
+                  status={traktStatus}
+                  loading={loadingTrakt}
+                  syncing={syncingTrakt}
+                  message={traktMessage}
+                  onDismissMessage={() => setTraktMessage(null)}
+                  onConnect={() => void connectTrakt()}
+                  onDisconnect={() => void disconnectTrakt()}
+                  onSync={() => void syncTraktRatings()}
+                />
+              </Grid>
             </Grid>
           </TabPanel>
         </Box>
@@ -1025,4 +275,3 @@ export function UserSettingsPage() {
     </Box>
   )
 }
-

--- a/apps/web/src/pages/UserSettings/AiExplanationPreferenceCard.tsx
+++ b/apps/web/src/pages/UserSettings/AiExplanationPreferenceCard.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  FormControlLabel,
+  Switch,
+  Typography,
+} from '@mui/material'
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
+import { useTranslation } from 'react-i18next'
+
+interface AiExplanationPreference {
+  overrideAllowed: boolean
+  userPreference: boolean | null
+  effectiveValue: boolean
+  globalEnabled: boolean
+  canOverride: boolean
+}
+
+export function AiExplanationPreferenceCard() {
+  const { t } = useTranslation()
+  const [pref, setPref] = useState<AiExplanationPreference | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const fetchPref = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch('/api/settings/user/ai-explanation', { credentials: 'include' })
+      if (response.ok) {
+        const data = (await response.json()) as AiExplanationPreference
+        setPref(data)
+      }
+    } catch {
+      // Optional load failures may degrade gracefully
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchPref()
+  }, [fetchPref])
+
+  const savePref = async (enabled: boolean | null) => {
+    if (!pref) return
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const response = await fetch('/api/settings/user/ai-explanation', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ enabled }),
+      })
+      if (response.ok) {
+        const data = (await response.json()) as {
+          userPreference: boolean | null
+          effectiveValue: boolean
+          message: string
+        }
+        setPref({
+          ...pref,
+          userPreference: data.userPreference,
+          effectiveValue: data.effectiveValue,
+        })
+        setSuccess(data.message)
+        window.setTimeout(() => setSuccess(null), 5000)
+      } else {
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setError(err.error || t('userSettings.errSavePreference'))
+      }
+    } catch {
+      setError(t('userSettings.errConnectServer'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!pref?.canOverride) {
+    return null
+  }
+
+  return (
+    <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AutoAwesomeIcon color="primary" />
+          {t('userSettings.aiExplanationTitle')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" mb={3}>
+          {t('userSettings.aiExplanationSubtitle')}
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {success && (
+          <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
+            {success}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={pref.userPreference ?? pref.globalEnabled}
+                  onChange={(e) => void savePref(e.target.checked)}
+                  disabled={saving}
+                />
+              }
+              label={
+                <Box>
+                  <Typography variant="body1" fontWeight="medium">
+                    {t('userSettings.aiExplanationIncludeTitle')}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {t('userSettings.aiExplanationIncludeBody')}
+                  </Typography>
+                </Box>
+              }
+              sx={{ alignItems: 'flex-start', ml: 0, mb: 2 }}
+            />
+
+            {pref.userPreference !== null && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => void savePref(null)}
+                disabled={saving}
+              >
+                {t('userSettings.aiExplanationReset', {
+                  state: pref.globalEnabled
+                    ? t('userSettings.stateEnabled')
+                    : t('userSettings.stateDisabled'),
+                })}
+              </Button>
+            )}
+
+            <Divider sx={{ my: 3 }} />
+
+            <Typography variant="caption" color="text.secondary">
+              {t('userSettings.aiExplanationFooter')}
+            </Typography>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/pages/UserSettings/AiLibraryNamesCard.tsx
+++ b/apps/web/src/pages/UserSettings/AiLibraryNamesCard.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  FormControl,
+  TextField,
+  Typography,
+} from '@mui/material'
+import SaveIcon from '@mui/icons-material/Save'
+import TextFieldsIcon from '@mui/icons-material/TextFields'
+import { useTranslation } from 'react-i18next'
+import type { User } from '@/hooks/auth-context'
+
+export function AiLibraryNamesCard({ user }: { user: User | null }) {
+  const { t } = useTranslation()
+  const [defaultLibraryPrefix, setDefaultLibraryPrefix] = useState('AI Picks - ')
+  const [moviesLibraryName, setMoviesLibraryName] = useState('')
+  const [seriesLibraryName, setSeriesLibraryName] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const fetchSettings = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/settings/user', { credentials: 'include' })
+      if (response.ok) {
+        const data = (await response.json()) as {
+          defaults?: { libraryNamePrefix?: string }
+          settings?: { libraryName?: string; seriesLibraryName?: string }
+        }
+        setDefaultLibraryPrefix(data.defaults?.libraryNamePrefix || 'AI Picks - ')
+        setMoviesLibraryName(data.settings?.libraryName || '')
+        setSeriesLibraryName(data.settings?.seriesLibraryName || '')
+      } else {
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setError(err.error || t('userSettings.errLoadUserSettings'))
+      }
+    } catch {
+      setError(t('userSettings.errConnectServer'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    void fetchSettings()
+  }, [fetchSettings])
+
+  const saveSettings = async () => {
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const response = await fetch('/api/settings/user', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          libraryName: moviesLibraryName.trim() || null,
+          seriesLibraryName: seriesLibraryName.trim() || null,
+        }),
+      })
+      if (response.ok) {
+        setSuccess(t('userSettings.libraryNamesSaved'))
+        window.setTimeout(() => setSuccess(null), 5000)
+      } else {
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setError(err.error || t('userSettings.errSaveSettings'))
+      }
+    } catch {
+      setError(t('userSettings.errConnectServer'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
+      <CardContent>
+        <Box display="flex" alignItems="center" gap={1} mb={1}>
+          <TextFieldsIcon color="primary" />
+          <Typography variant="h6">{t('userSettings.aiLibraryNamesTitle')}</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" mb={3}>
+          {t('userSettings.aiLibraryNamesSubtitle')}
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {success && (
+          <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
+            {success}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <>
+            <FormControl fullWidth sx={{ mb: 3 }}>
+              <Typography variant="body2" fontWeight={500} gutterBottom>
+                {t('userSettings.moviesLibraryNameLabel')}
+              </Typography>
+              <TextField
+                placeholder={`${defaultLibraryPrefix}${user?.displayName || user?.username || 'User'} - Movies`}
+                value={moviesLibraryName}
+                onChange={(e) => setMoviesLibraryName(e.target.value)}
+                size="small"
+                fullWidth
+                inputProps={{ maxLength: 100 }}
+                helperText={
+                  moviesLibraryName
+                    ? t('userSettings.libraryHelperNamedMovies', { name: moviesLibraryName })
+                    : t('userSettings.libraryHelperEmpty')
+                }
+              />
+            </FormControl>
+
+            <FormControl fullWidth sx={{ mb: 3 }}>
+              <Typography variant="body2" fontWeight={500} gutterBottom>
+                {t('userSettings.seriesLibraryNameLabel')}
+              </Typography>
+              <TextField
+                placeholder={`${defaultLibraryPrefix}${user?.displayName || user?.username || 'User'} - TV Series`}
+                value={seriesLibraryName}
+                onChange={(e) => setSeriesLibraryName(e.target.value)}
+                size="small"
+                fullWidth
+                inputProps={{ maxLength: 100 }}
+                helperText={
+                  seriesLibraryName
+                    ? t('userSettings.libraryHelperNamedSeries', { name: seriesLibraryName })
+                    : t('userSettings.libraryHelperEmpty')
+                }
+              />
+            </FormControl>
+
+            <Box display="flex" gap={1}>
+              <Button
+                variant="contained"
+                startIcon={saving ? <CircularProgress size={16} /> : <SaveIcon />}
+                onClick={() => void saveSettings()}
+                disabled={saving}
+                size="small"
+              >
+                {saving ? t('userSettings.saving') : t('common.save')}
+              </Button>
+              {(moviesLibraryName || seriesLibraryName) && (
+                <Button
+                  variant="outlined"
+                  onClick={() => {
+                    setMoviesLibraryName('')
+                    setSeriesLibraryName('')
+                  }}
+                  disabled={saving}
+                  size="small"
+                >
+                  {t('userSettings.resetToDefaults')}
+                </Button>
+              )}
+            </Box>
+
+            <Divider sx={{ my: 3 }} />
+
+            <Typography variant="caption" color="text.secondary">
+              {t('userSettings.aiLibraryFooter')}
+            </Typography>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/pages/UserSettings/AlgorithmSettingsSection.tsx
+++ b/apps/web/src/pages/UserSettings/AlgorithmSettingsSection.tsx
@@ -199,6 +199,9 @@ export function AlgorithmSettingsSection({ userId }: Props) {
         setIncludeWatched(value)
         setSuccess(t('algorithmSettings.successIncludeWatchedSaved'))
         setTimeout(() => setSuccess(null), 3000)
+      } else {
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setError(err.error || t('userSettings.errSavePreference'))
       }
     } catch {
       setError(t('userSettings.errSavePreference'))
@@ -220,6 +223,9 @@ export function AlgorithmSettingsSection({ userId }: Props) {
         setDislikeBehavior(value)
         setSuccess(t('algorithmSettings.successDislikeBehaviorSaved'))
         setTimeout(() => setSuccess(null), 3000)
+      } else {
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setError(err.error || t('userSettings.errSavePreference'))
       }
     } catch {
       setError(t('userSettings.errSavePreference'))

--- a/apps/web/src/pages/UserSettings/SimilarityGraphPrefsCard.tsx
+++ b/apps/web/src/pages/UserSettings/SimilarityGraphPrefsCard.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  FormControlLabel,
+  Switch,
+  Typography,
+} from '@mui/material'
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined'
+import { useTranslation } from 'react-i18next'
+
+interface SimilarityPrefs {
+  fullFranchiseMode: boolean
+  hideWatched: boolean
+}
+
+export function SimilarityGraphPrefsCard() {
+  const { t } = useTranslation()
+  const [prefs, setPrefs] = useState<SimilarityPrefs>({ fullFranchiseMode: false, hideWatched: true })
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const fetchPrefs = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch('/api/settings/user/similarity-prefs', { credentials: 'include' })
+      if (response.ok) {
+        const data = (await response.json()) as Partial<SimilarityPrefs>
+        setPrefs({
+          fullFranchiseMode: data.fullFranchiseMode ?? false,
+          hideWatched: data.hideWatched ?? true,
+        })
+      }
+    } catch {
+      // Optional load failures may degrade gracefully
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchPrefs()
+  }, [fetchPrefs])
+
+  const savePref = async (key: keyof SimilarityPrefs, value: boolean) => {
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const response = await fetch('/api/settings/user/similarity-prefs', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ [key]: value }),
+      })
+      if (response.ok) {
+        setPrefs((prev) => ({ ...prev, [key]: value }))
+        setSuccess(t('userSettings.preferenceSaved'))
+        window.setTimeout(() => setSuccess(null), 3000)
+      } else {
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setError(err.error || t('userSettings.errSavePreference'))
+      }
+    } catch {
+      setError(t('userSettings.errConnectServer'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
+      <CardContent>
+        <Box display="flex" alignItems="center" gap={1} mb={1}>
+          <HubOutlinedIcon color="primary" />
+          <Typography variant="h6">{t('userSettings.similarityGraphPrefsTitle')}</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" mb={3}>
+          {t('userSettings.similarityGraphPrefsSubtitle')}
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {success && (
+          <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
+            {success}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={prefs.hideWatched}
+                  onChange={(e) => void savePref('hideWatched', e.target.checked)}
+                  disabled={saving}
+                />
+              }
+              label={
+                <Box>
+                  <Typography variant="body1" fontWeight="medium">
+                    {t('userSettings.hideWatchedTitle')}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {prefs.hideWatched ? t('userSettings.hideWatchedOn') : t('userSettings.hideWatchedOff')}
+                  </Typography>
+                </Box>
+              }
+              sx={{ alignItems: 'flex-start', ml: 0, mb: 2 }}
+            />
+
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={prefs.fullFranchiseMode}
+                  onChange={(e) => void savePref('fullFranchiseMode', e.target.checked)}
+                  disabled={saving}
+                />
+              }
+              label={
+                <Box>
+                  <Typography variant="body1" fontWeight="medium">
+                    {t('userSettings.fullFranchiseTitle')}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {prefs.fullFranchiseMode
+                      ? t('userSettings.fullFranchiseOn')
+                      : t('userSettings.fullFranchiseOff')}
+                  </Typography>
+                </Box>
+              }
+              sx={{ alignItems: 'flex-start', ml: 0 }}
+            />
+
+            <Divider sx={{ my: 3 }} />
+
+            <Typography variant="caption" color="text.secondary">
+              {t('userSettings.similarityGraphFooter')}
+            </Typography>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/pages/UserSettings/TabPanel.tsx
+++ b/apps/web/src/pages/UserSettings/TabPanel.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Box } from '@mui/material'
+
+export interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+export function TabPanel({ children, value, index }: TabPanelProps) {
+  return (
+    <div role="tabpanel" hidden={value !== index}>
+      {value === index && <Box sx={{ pt: 3 }}>{children}</Box>}
+    </div>
+  )
+}

--- a/apps/web/src/pages/UserSettings/TraktIntegrationCard.tsx
+++ b/apps/web/src/pages/UserSettings/TraktIntegrationCard.tsx
@@ -1,0 +1,113 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  Typography,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import type { TraktMessage, TraktStatus } from './hooks/useTraktIntegration'
+
+interface TraktIntegrationCardProps {
+  status: TraktStatus | null
+  loading: boolean
+  syncing: boolean
+  message: TraktMessage | null
+  onDismissMessage: () => void
+  onConnect: () => void
+  onDisconnect: () => void
+  onSync: () => void
+}
+
+export function TraktIntegrationCard({
+  status,
+  loading,
+  syncing,
+  message,
+  onDismissMessage,
+  onConnect,
+  onDisconnect,
+  onSync,
+}: TraktIntegrationCardProps) {
+  const { t } = useTranslation()
+
+  if (!status?.traktConfigured) {
+    return null
+  }
+
+  return (
+    <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, height: '100%' }}>
+      <CardContent>
+        <Box display="flex" alignItems="center" gap={1} mb={1}>
+          <Box
+            component="img"
+            src="/trakt.svg"
+            alt={t('userSettings.traktAlt')}
+            sx={{ width: 28, height: 28, filter: 'brightness(0) invert(1)' }}
+          />
+          <Typography variant="h6">{t('userSettings.traktTitle')}</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" mb={3}>
+          {t('userSettings.traktSubtitle')}
+        </Typography>
+
+        {message && (
+          <Alert severity={message.type} sx={{ mb: 2 }} onClose={onDismissMessage}>
+            {message.text}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress />
+          </Box>
+        ) : status.connected ? (
+          <>
+            <Box sx={{ bgcolor: 'action.hover', p: 2, borderRadius: 1, mb: 2 }}>
+              <Typography variant="body2" fontWeight={500}>
+                {t('userSettings.traktConnectedAs', { username: status.username ?? '' })}
+              </Typography>
+              {status.syncedAt && (
+                <Typography variant="caption" color="text.secondary">
+                  {t('userSettings.traktLastSynced', {
+                    when: new Date(status.syncedAt).toLocaleString(),
+                  })}
+                </Typography>
+              )}
+            </Box>
+
+            <Box display="flex" gap={1}>
+              <Button variant="contained" onClick={onSync} disabled={syncing} size="small">
+                {syncing ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null}
+                {syncing ? t('userSettings.traktSyncing') : t('userSettings.traktSyncRatings')}
+              </Button>
+              <Button variant="outlined" color="error" onClick={onDisconnect} size="small">
+                {t('userSettings.traktDisconnect')}
+              </Button>
+            </Box>
+          </>
+        ) : (
+          <Button
+            variant="contained"
+            onClick={onConnect}
+            sx={{
+              bgcolor: '#ed1c24',
+              '&:hover': { bgcolor: '#c9171d' },
+            }}
+          >
+            {t('userSettings.traktConnect')}
+          </Button>
+        )}
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="caption" color="text.secondary">
+          {t('userSettings.traktFooter')}
+        </Typography>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/pages/UserSettings/UserProfileTab.tsx
+++ b/apps/web/src/pages/UserSettings/UserProfileTab.tsx
@@ -1,0 +1,181 @@
+import {
+  Alert,
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  FormControlLabel,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import type { User } from '@/hooks/auth-context'
+
+interface UserProfileTabProps {
+  user: User | null
+  email: string
+  originalEmail: string
+  emailLocked: boolean
+  emailNotificationsEnabled: boolean
+  loadingEmail: boolean
+  savingEmail: boolean
+  emailSuccess: string | null
+  onEmailChange: (value: string) => void
+  onEmailBlur: () => void
+  onNotificationsChange: (enabled: boolean) => void
+  onDismissSuccess: () => void
+  emailError?: string | null
+  onDismissEmailError?: () => void
+}
+
+export function UserProfileTab({
+  user,
+  email,
+  emailLocked,
+  emailNotificationsEnabled,
+  loadingEmail,
+  savingEmail,
+  emailSuccess,
+  onEmailChange,
+  onEmailBlur,
+  onNotificationsChange,
+  onDismissSuccess,
+  emailError,
+  onDismissEmailError,
+}: UserProfileTabProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Card sx={{ backgroundColor: 'background.default', borderRadius: 2, maxWidth: 600 }}>
+      <CardContent>
+        <Box display="flex" alignItems="center" gap={3} mb={4}>
+          <Avatar
+            src={user?.avatarUrl || undefined}
+            sx={{
+              width: 72,
+              height: 72,
+              bgcolor: 'primary.main',
+              fontSize: '1.75rem',
+            }}
+          >
+            {user?.username?.[0]?.toUpperCase() || 'U'}
+          </Avatar>
+          <Box>
+            <Typography variant="h6" fontWeight={600}>
+              {user?.displayName || user?.username}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {user?.isAdmin ? t('userSettings.roleAdmin') : t('userSettings.roleUser')} •{' '}
+              {user?.provider ? user.provider.charAt(0).toUpperCase() + user.provider.slice(1) : ''}
+            </Typography>
+          </Box>
+        </Box>
+
+        <TextField
+          label={t('login.username')}
+          value={user?.username || ''}
+          fullWidth
+          margin="normal"
+          disabled
+          size="small"
+        />
+
+        <TextField
+          label={t('userSettings.displayName')}
+          value={user?.displayName || user?.username || ''}
+          fullWidth
+          margin="normal"
+          disabled
+          size="small"
+        />
+
+        <TextField
+          label={t('userSettings.mediaServer')}
+          value={user?.provider ? user.provider.charAt(0).toUpperCase() + user.provider.slice(1) : ''}
+          fullWidth
+          margin="normal"
+          disabled
+          size="small"
+        />
+
+        <TextField
+          label={t('userSettings.roleField')}
+          value={user?.isAdmin ? t('userSettings.roleAdmin') : t('userSettings.roleUser')}
+          fullWidth
+          margin="normal"
+          disabled
+          size="small"
+        />
+
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
+          {t('userSettings.profileSyncedCaption')}
+        </Typography>
+
+        <Divider sx={{ my: 3 }} />
+
+        <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+          {t('userSettings.emailSectionTitle')}
+        </Typography>
+
+        {emailError && onDismissEmailError && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={onDismissEmailError}>
+            {emailError}
+          </Alert>
+        )}
+
+        {emailSuccess && (
+          <Alert severity="success" sx={{ mb: 2 }} onClose={onDismissSuccess}>
+            {emailSuccess}
+          </Alert>
+        )}
+
+        {loadingEmail ? (
+          <Box display="flex" justifyContent="center" py={2}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : (
+          <>
+            <TextField
+              label={t('userSettings.emailAddress')}
+              value={email}
+              onChange={(e) => onEmailChange(e.target.value)}
+              fullWidth
+              margin="normal"
+              size="small"
+              placeholder={t('userSettings.emailPlaceholder')}
+              helperText={
+                emailLocked ? t('userSettings.emailHelperCustom') : t('userSettings.emailHelperSynced')
+              }
+              InputProps={{
+                endAdornment: savingEmail ? <CircularProgress size={16} /> : null,
+              }}
+              onBlur={onEmailBlur}
+            />
+
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={emailNotificationsEnabled}
+                  onChange={(e) => onNotificationsChange(e.target.checked)}
+                  disabled={savingEmail}
+                />
+              }
+              label={
+                <Box>
+                  <Typography variant="body2">{t('userSettings.emailNotificationsTitle')}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {t('userSettings.emailNotificationsSubtitle')}
+                  </Typography>
+                </Box>
+              }
+              sx={{ mt: 1, alignItems: 'flex-start' }}
+            />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/pages/UserSettings/hooks/useTraktIntegration.ts
+++ b/apps/web/src/pages/UserSettings/hooks/useTraktIntegration.ts
@@ -1,0 +1,128 @@
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface TraktStatus {
+  traktConfigured: boolean
+  connected: boolean
+  username: string | null
+  syncedAt: string | null
+}
+
+export interface TraktMessage {
+  type: 'success' | 'error'
+  text: string
+}
+
+export function useTraktIntegration() {
+  const { t } = useTranslation()
+  const [status, setStatus] = useState<TraktStatus | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const [message, setMessage] = useState<TraktMessage | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch('/api/trakt/status', { credentials: 'include' })
+      if (response.ok) {
+        const data = (await response.json()) as TraktStatus
+        setStatus(data)
+      }
+    } catch {
+      // Optional load failures may degrade gracefully
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const connect = useCallback(async () => {
+    try {
+      const response = await fetch('/api/trakt/auth-url', { credentials: 'include' })
+      if (response.ok) {
+        const data = (await response.json()) as { authUrl: string }
+        window.location.href = data.authUrl
+        return
+      }
+      const err = (await response.json().catch(() => ({}))) as { error?: string }
+      setMessage({ type: 'error', text: err.error || t('userSettings.traktErrStart') })
+    } catch {
+      setMessage({ type: 'error', text: t('userSettings.errConnectServer') })
+    }
+  }, [t])
+
+  const disconnect = useCallback(async () => {
+    try {
+      const response = await fetch('/api/trakt/disconnect', {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (response.ok) {
+        setStatus((prev) =>
+          prev ? { ...prev, connected: false, username: null, syncedAt: null } : null
+        )
+        setMessage({ type: 'success', text: t('userSettings.traktDisconnected') })
+        window.setTimeout(() => setMessage(null), 3000)
+        return
+      }
+      const err = (await response.json().catch(() => ({}))) as { error?: string }
+      setMessage({ type: 'error', text: err.error || t('userSettings.traktErrDisconnect') })
+    } catch {
+      setMessage({ type: 'error', text: t('userSettings.traktErrDisconnect') })
+    }
+  }, [t])
+
+  const syncRatings = useCallback(async () => {
+    setSyncing(true)
+    setMessage(null)
+    try {
+      const response = await fetch('/api/trakt/sync', {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (response.ok) {
+        const data = (await response.json()) as { message: string }
+        setMessage({ type: 'success', text: data.message })
+        await fetchStatus()
+        return
+      }
+      const err = (await response.json().catch(() => ({}))) as { error?: string }
+      setMessage({ type: 'error', text: err.error || t('userSettings.traktErrSync') })
+    } catch {
+      setMessage({ type: 'error', text: t('userSettings.errConnectServer') })
+    } finally {
+      setSyncing(false)
+    }
+  }, [fetchStatus, t])
+
+  const handleCallbackFromUrl = useCallback(() => {
+    const params = new URLSearchParams(window.location.hash.split('?')[1] || '')
+    if (params.get('trakt') === 'success') {
+      const username = params.get('username')
+      setMessage({
+        type: 'success',
+        text: t('userSettings.traktSuccessConnect', { username: username ?? '' }),
+      })
+      void fetchStatus()
+      window.history.replaceState(null, '', window.location.pathname + '#/settings')
+      return
+    }
+    if (params.get('trakt') === 'error') {
+      const callbackMessage = params.get('message') || t('userSettings.traktErrUnknown')
+      setMessage({ type: 'error', text: t('userSettings.traktFailConnect', { message: callbackMessage }) })
+      window.history.replaceState(null, '', window.location.pathname + '#/settings')
+    }
+  }, [fetchStatus, t])
+
+  return {
+    status,
+    loading,
+    syncing,
+    message,
+    setMessage,
+    fetchStatus,
+    connect,
+    disconnect,
+    syncRatings,
+    handleCallbackFromUrl,
+  }
+}

--- a/apps/web/src/pages/UserSettings/hooks/useUserPreference.ts
+++ b/apps/web/src/pages/UserSettings/hooks/useUserPreference.ts
@@ -1,0 +1,101 @@
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface UseUserPreferenceOptions<T> {
+  fetchUrl: string
+  parse: (data: Record<string, unknown>) => T
+  enabled?: boolean
+}
+
+interface SaveUserPreferenceOptions<T> {
+  saveUrl: string
+  method?: 'PATCH' | 'PUT' | 'POST'
+  buildBody: (value: T) => Record<string, unknown>
+  successMessageKey?: string
+}
+
+export function useUserPreference<T>(
+  options: UseUserPreferenceOptions<T>,
+  saveOptions?: SaveUserPreferenceOptions<T>
+) {
+  const { t } = useTranslation()
+  const { fetchUrl, parse, enabled = true } = options
+  const [value, setValue] = useState<T | null>(null)
+  const [loading, setLoading] = useState(enabled)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const fetchValue = useCallback(async () => {
+    if (!enabled) return
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch(fetchUrl, { credentials: 'include' })
+      if (response.ok) {
+        const data = (await response.json()) as Record<string, unknown>
+        setValue(parse(data))
+      }
+    } catch {
+      // Optional load failures may degrade gracefully
+    } finally {
+      setLoading(false)
+    }
+  }, [enabled, fetchUrl, parse])
+
+  const saveValue = useCallback(
+    async (nextValue: T) => {
+      if (!saveOptions) return false
+      setSaving(true)
+      setError(null)
+      setSuccess(null)
+      try {
+        const response = await fetch(saveOptions.saveUrl, {
+          method: saveOptions.method ?? 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(saveOptions.buildBody(nextValue)),
+        })
+        if (response.ok) {
+          setValue(nextValue)
+          if (saveOptions.successMessageKey) {
+            setSuccess(t(saveOptions.successMessageKey))
+            window.setTimeout(() => setSuccess(null), 3000)
+          }
+          return true
+        }
+        const err = (await response.json().catch(() => ({}))) as { error?: string }
+        setError(err.error || t('userSettings.errSavePreference'))
+        return false
+      } catch {
+        setError(t('userSettings.errConnectServer'))
+        return false
+      } finally {
+        setSaving(false)
+      }
+    },
+    [saveOptions, t]
+  )
+
+  const patchValue = useCallback(
+    async (partial: Partial<T>, merge: (current: T, partial: Partial<T>) => T) => {
+      if (value === null) return false
+      return saveValue(merge(value, partial))
+    },
+    [saveValue, value]
+  )
+
+  return {
+    value,
+    setValue,
+    loading,
+    saving,
+    error,
+    setError,
+    success,
+    setSuccess,
+    fetchValue,
+    saveValue,
+    patchValue,
+  }
+}

--- a/apps/web/src/pages/UserSettings/tabHelpers.ts
+++ b/apps/web/src/pages/UserSettings/tabHelpers.ts
@@ -1,0 +1,11 @@
+export const USER_SETTINGS_TAB_KEYS = ['profile', 'watcher', 'algorithm', 'preferences'] as const
+
+export function userSettingsTabIndexFromParam(tab: string | null): number {
+  if (!tab) return 0
+  const idx = USER_SETTINGS_TAB_KEYS.indexOf(tab as (typeof USER_SETTINGS_TAB_KEYS)[number])
+  return idx >= 0 ? idx : 0
+}
+
+export function userSettingsTabParamFromIndex(index: number): string {
+  return USER_SETTINGS_TAB_KEYS[index] ?? 'profile'
+}


### PR DESCRIPTION
## Summary
- Extract preference hooks, tab shell helpers, and preference cards
- Slim UserSettings.tsx to tab shell
- Surface save errors for email, similarity, algorithm prefs

## Test plan
- [x] pnpm validate