### PR TITLE
refactor(core): extract Emby provider helpers

### DIFF
--- a/packages/core/src/media/emby/base.ts
+++ b/packages/core/src/media/emby/base.ts
@@ -1,11 +1,16 @@
 /**
  * Emby Provider Base
- *
- * Core class with constructor, authentication helpers, and fetch functionality.
- * Extended by other modules for specific functionality.
  */
 
 import { createChildLogger } from '../../lib/logger.js'
+import {
+  EMBY_FETCH_TIMEOUT_MS,
+  embyConnectionError,
+  embyHttpError,
+  embyTimeoutError,
+  parseEmbyResponseBody,
+  summarizeEmbyItemsResponse,
+} from './fetchHelpers.js'
 
 export const logger = createChildLogger('emby-provider')
 
@@ -18,7 +23,7 @@ export class EmbyProviderBase {
   protected readonly clientVersion = '1.0.0'
 
   constructor(baseUrl: string) {
-    this.baseUrl = baseUrl.replace(/\/$/, '') // Remove trailing slash
+    this.baseUrl = baseUrl.replace(/\/$/, '')
   }
 
   getAuthHeader(apiKey: string): string {
@@ -35,9 +40,8 @@ export class EmbyProviderBase {
 
     logger.debug({ method: options.method || 'GET', url }, '📡 Emby API Request')
 
-    // Add 60 second timeout with AbortController (increased from 30s for large libraries)
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 60000)
+    const timeoutId = setTimeout(() => controller.abort(), EMBY_FETCH_TIMEOUT_MS)
 
     const startTime = Date.now()
     let response: Response
@@ -51,15 +55,14 @@ export class EmbyProviderBase {
       clearTimeout(timeoutId)
       const duration = Date.now() - startTime
       if (err instanceof Error && err.name === 'AbortError') {
-        logger.error({ url, duration }, '⏱️ Emby API request timed out after 60 seconds')
-        throw new Error(
-          `Connection to Emby timed out after 60 seconds. Please check that your media server URL (${this.baseUrl}) is accessible from the Aperture container.`
+        logger.error(
+          { url, duration },
+          `⏱️ Emby API request timed out after ${EMBY_FETCH_TIMEOUT_MS / 1000} seconds`
         )
+        throw embyTimeoutError(this.baseUrl)
       }
       logger.error({ url, duration, err }, '❌ Emby API network error')
-      throw new Error(
-        `Failed to connect to Emby at ${this.baseUrl}. Please verify the URL is correct and the server is running.`
-      )
+      throw embyConnectionError(this.baseUrl)
     } finally {
       clearTimeout(timeoutId)
     }
@@ -68,31 +71,23 @@ export class EmbyProviderBase {
     if (!response.ok) {
       const text = await response.text()
       logger.error({ status: response.status, url, body: text, duration }, '❌ Emby API error')
-      throw new Error(`Emby API error: ${response.status} ${response.statusText}`)
+      throw embyHttpError(response.status, response.statusText)
     }
 
-    // Some endpoints return empty response
     const text = await response.text()
     if (!text) {
       logger.debug({ url, duration, empty: true }, '✅ Emby API Response (empty)')
       return {} as T
     }
 
-    const data = JSON.parse(text) as T
+    const data = parseEmbyResponseBody<T>(text)
 
-    // Log response summary
     logger.debug(
       {
         url,
         duration,
         responseSize: text.length,
-        // If it's an items response, log count
-        ...(typeof data === 'object' && data !== null && 'Items' in data
-          ? {
-              itemCount: (data as { Items?: unknown[] }).Items?.length,
-              totalRecordCount: (data as { TotalRecordCount?: number }).TotalRecordCount,
-            }
-          : {}),
+        ...summarizeEmbyItemsResponse(data),
       },
       '✅ Emby API Response'
     )
@@ -100,7 +95,6 @@ export class EmbyProviderBase {
     return data
   }
 
-  // Utility methods for image URLs
   getPosterUrl(itemId: string, imageTag?: string): string {
     const params = imageTag ? `?tag=${imageTag}` : ''
     return `${this.baseUrl}/Items/${itemId}/Images/Primary${params}`
@@ -135,6 +129,3 @@ export class EmbyProviderBase {
     return `${this.baseUrl}/Videos/${itemId}/stream`
   }
 }
-
-
-

--- a/packages/core/src/media/emby/collections.ts
+++ b/packages/core/src/media/emby/collections.ts
@@ -1,34 +1,27 @@
 /**
  * Emby Collections (Box Sets) Module
- * 
- * Collections appear as Box Sets in the media server and group items within libraries.
- * Unlike Playlists, Collections appear in the normal library browse view.
  */
 
 import type { CollectionCreateResult } from '../types.js'
 import type { EmbyItemsResponse } from './types.js'
 import type { EmbyProviderBase } from './base.js'
+import { setForcedSortName, updateEmbyItemSafely } from './itemUpdates.js'
+import {
+  buildCollectionCreateParams,
+  buildItemSearchParams,
+  collectionChildItemsQuery,
+  collectionItemsPath,
+} from './requestBuilders.js'
 
-/**
- * Create or update a collection (Box Set)
- * Items are added in the order provided and their sort names are set to maintain rank order.
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param name - Collection name
- * @param itemIds - Array of media item IDs to include (in ranked order)
- * @returns Collection ID
- */
 export async function createOrUpdateCollection(
   provider: EmbyProviderBase,
   apiKey: string,
   name: string,
   itemIds: string[]
 ): Promise<CollectionCreateResult> {
-  // First, try to find existing collection (Box Set)
-  const params = new URLSearchParams({
-    IncludeItemTypes: 'BoxSet',
-    Recursive: 'true',
-    SearchTerm: name,
+  const params = buildItemSearchParams({
+    includeItemTypes: 'BoxSet',
+    searchTerm: name,
   })
 
   const existing = await provider.fetch<EmbyItemsResponse>(`/Items?${params}`, apiKey)
@@ -38,59 +31,41 @@ export async function createOrUpdateCollection(
 
   if (collection) {
     collectionId = collection.Id
-    
-    // Get existing items in the collection
+
     const existingItems = await provider.fetch<EmbyItemsResponse>(
-      `/Items?ParentId=${collection.Id}&Recursive=true`,
+      collectionChildItemsQuery(collection.Id),
       apiKey
     )
 
-    // Remove all existing items if any
     if (existingItems.Items && existingItems.Items.length > 0) {
-      const existingIds = existingItems.Items.map((item) => item.Id).join(',')
-      await provider.fetch(`/Collections/${collection.Id}/Items?Ids=${existingIds}`, apiKey, {
+      const existingIds = existingItems.Items.map((item) => item.Id)
+      await provider.fetch(collectionItemsPath(collection.Id, existingIds), apiKey, {
         method: 'DELETE',
       })
     }
 
-    // Add new items
     if (itemIds.length > 0) {
-      await provider.fetch(`/Collections/${collection.Id}/Items?Ids=${itemIds.join(',')}`, apiKey, {
+      await provider.fetch(collectionItemsPath(collection.Id, itemIds), apiKey, {
         method: 'POST',
       })
     }
   } else {
-    // Create new collection
-    const createParams = new URLSearchParams({
-      Name: name,
-    })
-
-    if (itemIds.length > 0) {
-      createParams.set('Ids', itemIds.join(','))
-    }
+    const createParams = buildCollectionCreateParams(name, itemIds)
 
     const created = await provider.fetch<{ Id: string }>(`/Collections?${createParams}`, apiKey, {
       method: 'POST',
     })
-    
+
     collectionId = created.Id
 
-    // Set sort title to force collection to sort at top
     await setCollectionSortTitle(provider, apiKey, collectionId, name)
   }
 
-  // Set sort names on items to maintain rank order (01, 02, 03, etc.)
   await setItemRankSortNames(provider, apiKey, itemIds)
 
   return { collectionId }
 }
 
-/**
- * Delete a collection
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param collectionId - Collection ID to delete
- */
 export async function deleteCollection(
   provider: EmbyProviderBase,
   apiKey: string,
@@ -99,33 +74,19 @@ export async function deleteCollection(
   await provider.fetch(`/Items/${collectionId}`, apiKey, { method: 'DELETE' })
 }
 
-/**
- * Get items in a collection
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param collectionId - Collection ID
- * @returns Array of item IDs
- */
 export async function getCollectionItems(
   provider: EmbyProviderBase,
   apiKey: string,
   collectionId: string
 ): Promise<string[]> {
   const response = await provider.fetch<EmbyItemsResponse>(
-    `/Items?ParentId=${collectionId}&Recursive=true`,
+    collectionChildItemsQuery(collectionId),
     apiKey
   )
 
   return response.Items.map((item) => item.Id)
 }
 
-/**
- * Add items to a collection
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param collectionId - Collection ID
- * @param itemIds - Array of item IDs to add
- */
 export async function addCollectionItems(
   provider: EmbyProviderBase,
   apiKey: string,
@@ -133,18 +94,11 @@ export async function addCollectionItems(
   itemIds: string[]
 ): Promise<void> {
   if (itemIds.length === 0) return
-  await provider.fetch(`/Collections/${collectionId}/Items?Ids=${itemIds.join(',')}`, apiKey, {
+  await provider.fetch(collectionItemsPath(collectionId, itemIds), apiKey, {
     method: 'POST',
   })
 }
 
-/**
- * Remove items from a collection
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param collectionId - Collection ID
- * @param itemIds - Array of item IDs to remove
- */
 export async function removeCollectionItems(
   provider: EmbyProviderBase,
   apiKey: string,
@@ -152,81 +106,47 @@ export async function removeCollectionItems(
   itemIds: string[]
 ): Promise<void> {
   if (itemIds.length === 0) return
-  await provider.fetch(`/Collections/${collectionId}/Items?Ids=${itemIds.join(',')}`, apiKey, {
+  await provider.fetch(collectionItemsPath(collectionId, itemIds), apiKey, {
     method: 'DELETE',
   })
 }
 
-/**
- * Find a collection by name
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param name - Collection name to search for
- * @returns Collection ID if found, null otherwise
- */
 export async function findCollectionByName(
   provider: EmbyProviderBase,
   apiKey: string,
   name: string
 ): Promise<string | null> {
-  const params = new URLSearchParams({
-    IncludeItemTypes: 'BoxSet',
-    Recursive: 'true',
-    SearchTerm: name,
+  const params = buildItemSearchParams({
+    includeItemTypes: 'BoxSet',
+    searchTerm: name,
   })
 
   const response = await provider.fetch<EmbyItemsResponse>(`/Items?${params}`, apiKey)
   const collection = response.Items.find((c) => c.Name === name)
-  
+
   return collection?.Id ?? null
 }
 
-/**
- * Set the sort title for a collection to force it to appear at the top
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param collectionId - Collection ID
- * @param name - Display name of the collection
- */
 async function setCollectionSortTitle(
   provider: EmbyProviderBase,
   apiKey: string,
   collectionId: string,
   name: string
 ): Promise<void> {
-  // Prepend !!!!!! to sort title so collection appears at top when sorted alphabetically
   const sortTitle = `!!!!!!${name}`
-  
-  try {
-    // First, fetch the full item data (required by Emby API for updates)
-    const item = await provider.fetch<Record<string, unknown>>(
-      `/Items/${collectionId}`,
-      apiKey
-    )
-    
-    // Update the sort name and lock it to prevent automatic overwrites
-    item.ForcedSortName = sortTitle
-    item.LockedFields = ['SortName']
-    
-    // POST the full item back
-    await provider.fetch(`/Items/${collectionId}`, apiKey, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(item),
-    })
-  } catch {
-    // Non-fatal: collection will still work, just won't sort to top
-    console.warn(`Failed to set sort title for collection ${collectionId}`)
-  }
+
+  await updateEmbyItemSafely(
+    provider,
+    apiKey,
+    `/Items/${collectionId}`,
+    (item) => {
+      setForcedSortName(item, sortTitle, false)
+      item.LockedFields = ['SortName']
+    },
+    { collectionId, operation: 'setCollectionSortTitle' }
+  )
 }
 
-/**
- * Set sort names on items to maintain rank order within collections
- * Each item gets a sort name prefixed with its rank: "01 - Title", "02 - Title", etc.
- * @param provider - Emby provider instance
- * @param apiKey - API key for authentication
- * @param itemIds - Array of item IDs in ranked order
- */
 async function setItemRankSortNames(
   provider: EmbyProviderBase,
   apiKey: string,
@@ -234,39 +154,17 @@ async function setItemRankSortNames(
 ): Promise<void> {
   for (let i = 0; i < itemIds.length; i++) {
     const itemId = itemIds[i]
-    const rank = i + 1
-    const rankPrefix = String(rank).padStart(2, '0')
-    
-    try {
-      // Fetch the full item data
-      const item = await provider.fetch<Record<string, unknown>>(
-        `/Items/${itemId}`,
-        apiKey
-      )
-      
-      // Get the original name for the sort title
-      const originalName = item.Name || 'Unknown'
-      const sortTitle = `${rankPrefix} - ${originalName}`
-      
-      // Update the sort name and lock it
-      item.ForcedSortName = sortTitle
-      
-      // Merge with existing locked fields if any
-      const existingLocked = Array.isArray(item.LockedFields) ? item.LockedFields : []
-      if (!existingLocked.includes('SortName')) {
-        item.LockedFields = [...existingLocked, 'SortName']
-      }
-      
-      // POST the full item back
-      await provider.fetch(`/Items/${itemId}`, apiKey, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(item),
-      })
-    } catch {
-      // Non-fatal: item will still be in collection, just won't sort by rank
-      console.warn(`Failed to set rank sort name for item ${itemId}`)
-    }
+    const rankPrefix = String(i + 1).padStart(2, '0')
+
+    await updateEmbyItemSafely(
+      provider,
+      apiKey,
+      `/Items/${itemId}`,
+      (item) => {
+        const originalName = item.Name || 'Unknown'
+        setForcedSortName(item, `${rankPrefix} - ${originalName}`)
+      },
+      { itemId, operation: 'setItemRankSortName' }
+    )
   }
 }
-

--- a/packages/core/src/media/emby/favorites.ts
+++ b/packages/core/src/media/emby/favorites.ts
@@ -4,6 +4,7 @@
 
 import type { EmbyProviderBase } from './base.js'
 import { logger } from './base.js'
+import { isEmbyNotFoundError } from './fetchHelpers.js'
 
 interface EmbyItemsIdResponse {
   Items: { Id: string }[]
@@ -75,8 +76,7 @@ export async function unfavoriteSeriesItem(
   try {
     await provider.fetch(path, apiKey, { method: 'DELETE' })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    if (msg.includes('404')) {
+    if (isEmbyNotFoundError(err)) {
       logger.debug({ userId, itemId }, 'Unfavorite noop (already not favorite)')
       return
     }

--- a/packages/core/src/media/emby/fetchHelpers.ts
+++ b/packages/core/src/media/emby/fetchHelpers.ts
@@ -1,0 +1,44 @@
+/**
+ * Emby fetch helpers — timeout, error normalization, and response parsing.
+ */
+
+export const EMBY_FETCH_TIMEOUT_MS = 60_000
+
+export function embyTimeoutError(baseUrl: string): Error {
+  return new Error(
+    `Connection to Emby timed out after ${EMBY_FETCH_TIMEOUT_MS / 1000} seconds. Please check that your media server URL (${baseUrl}) is accessible from the Aperture container.`
+  )
+}
+
+export function embyConnectionError(baseUrl: string): Error {
+  return new Error(
+    `Failed to connect to Emby at ${baseUrl}. Please verify the URL is correct and the server is running.`
+  )
+}
+
+export function embyHttpError(status: number, statusText: string): Error {
+  return new Error(`Emby API error: ${status} ${statusText}`)
+}
+
+export function isEmbyNotFoundError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg.includes('404')
+}
+
+export function parseEmbyResponseBody<T>(text: string): T {
+  if (!text) {
+    return {} as T
+  }
+  return JSON.parse(text) as T
+}
+
+export function summarizeEmbyItemsResponse(data: unknown): Record<string, unknown> {
+  if (typeof data !== 'object' || data === null || !('Items' in data)) {
+    return {}
+  }
+  const itemsResponse = data as { Items?: unknown[]; TotalRecordCount?: number }
+  return {
+    itemCount: itemsResponse.Items?.length,
+    totalRecordCount: itemsResponse.TotalRecordCount,
+  }
+}

--- a/packages/core/src/media/emby/index.ts
+++ b/packages/core/src/media/emby/index.ts
@@ -6,6 +6,12 @@ export { EmbyProviderBase } from './base.js'
 export * from './types.js'
 export { mapEmbyItemToMovie, mapEmbyItemToSeries, mapEmbyItemToEpisode } from './mappers.js'
 
+// Helper modules
+export * from './fetchHelpers.js'
+export * from './requestBuilders.js'
+export * from './itemUpdates.js'
+export * from './mapperHelpers.js'
+
 // Module functions (for direct import if needed)
 export * from './auth.js'
 export * from './users.js'

--- a/packages/core/src/media/emby/itemUpdates.ts
+++ b/packages/core/src/media/emby/itemUpdates.ts
@@ -1,0 +1,56 @@
+/**
+ * Emby item update helpers — fetch/modify/post pattern required by the Emby API.
+ */
+
+import { logger } from './base.js'
+import type { EmbyProviderBase } from './base.js'
+
+export async function updateEmbyItem(
+  provider: EmbyProviderBase,
+  apiKey: string,
+  fetchPath: string,
+  mutate: (item: Record<string, unknown>) => void
+): Promise<string> {
+  const item = await provider.fetch<Record<string, unknown>>(fetchPath, apiKey)
+  mutate(item)
+
+  const itemId = (item.Id as string) || fetchPath.split('/').pop() || ''
+  await provider.fetch(`/Items/${itemId}`, apiKey, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(item),
+  })
+
+  return itemId
+}
+
+export async function updateEmbyItemSafely(
+  provider: EmbyProviderBase,
+  apiKey: string,
+  fetchPath: string,
+  mutate: (item: Record<string, unknown>) => void,
+  context: Record<string, unknown>
+): Promise<void> {
+  try {
+    await updateEmbyItem(provider, apiKey, fetchPath, mutate)
+  } catch (err) {
+    logger.warn({ err, ...context }, 'Non-fatal Emby item update failed')
+  }
+}
+
+export function setForcedSortName(
+  item: Record<string, unknown>,
+  sortName: string,
+  lockSortName = true
+): void {
+  item.ForcedSortName = sortName
+
+  if (!lockSortName) {
+    return
+  }
+
+  const existingLocked = Array.isArray(item.LockedFields) ? item.LockedFields : []
+  if (!existingLocked.includes('SortName')) {
+    item.LockedFields = [...existingLocked, 'SortName']
+  }
+}

--- a/packages/core/src/media/emby/mapperHelpers.ts
+++ b/packages/core/src/media/emby/mapperHelpers.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared Emby item mapping utilities used by movie/series/episode mappers.
+ */
+
+import type { EmbyItem, EmbyEpisode } from './types.js'
+import type { WatchedItem, WatchedEpisode } from '../types.js'
+
+type EmbyPerson = {
+  Name: string
+  Id?: string
+  Role?: string
+  Type: string
+}
+
+type EmbyUserData = {
+  PlayCount: number
+  IsFavorite: boolean
+  LastPlayedDate?: string
+  PlaybackPositionTicks?: number
+  Played: boolean
+}
+
+type EmbyMediaSource = {
+  Id: string
+  Path: string
+  Container: string
+  Size?: number
+  Bitrate?: number
+  MediaStreams?: Array<{
+    Type: string
+    Codec?: string
+    Width?: number
+    Height?: number
+  }>
+}
+
+export function personThumbUrl(baseUrl: string, name: string): string {
+  return `${baseUrl}/Persons/${encodeURIComponent(name)}/Images/Primary`
+}
+
+export function extractPeopleNames(people: EmbyPerson[] | undefined, types: string[]): string[] {
+  return people?.filter((p) => types.includes(p.Type)).map((p) => p.Name) || []
+}
+
+export function mapEmbyActors(people: EmbyPerson[] | undefined, baseUrl: string, limit = 20) {
+  return (
+    people
+      ?.filter((p) => p.Type === 'Actor')
+      .slice(0, limit)
+      .map((p) => ({
+        name: p.Name,
+        role: p.Role,
+        ...(p.Id ? { personId: String(p.Id) } : {}),
+        thumb: p.Name ? personThumbUrl(baseUrl, p.Name) : undefined,
+      })) || []
+  )
+}
+
+export function mapEmbyGuestStars(people: EmbyPerson[] | undefined, baseUrl: string, limit = 10) {
+  return (
+    people
+      ?.filter((p) => p.Type === 'GuestStar')
+      .slice(0, limit)
+      .map((p) => ({
+        name: p.Name,
+        role: p.Role,
+        thumb: p.Name ? personThumbUrl(baseUrl, p.Name) : undefined,
+      })) || []
+  )
+}
+
+export function mapEmbyStudios(studios: Array<{ Name: string; Id?: number | string }> | undefined) {
+  return (
+    studios?.map((s) => ({
+      id: s.Id?.toString(),
+      name: s.Name,
+    })) || []
+  )
+}
+
+export function mapEmbyMediaSources(sources: EmbyMediaSource[] | undefined) {
+  return sources?.map((ms) => ({
+    id: ms.Id,
+    path: ms.Path,
+    container: ms.Container,
+    size: ms.Size,
+    bitrate: ms.Bitrate,
+  }))
+}
+
+export function mapEmbyUserData(userData: EmbyUserData | undefined, includePosition = false) {
+  if (!userData) {
+    return undefined
+  }
+
+  return {
+    playCount: userData.PlayCount,
+    isFavorite: userData.IsFavorite,
+    lastPlayedDate: userData.LastPlayedDate,
+    ...(includePosition ? { playbackPositionTicks: userData.PlaybackPositionTicks } : {}),
+    played: userData.Played,
+  }
+}
+
+export function mapEmbyVideoQuality(primarySource: EmbyMediaSource | undefined) {
+  const videoStream = primarySource?.MediaStreams?.find((s) => s.Type === 'Video')
+  const audioStream = primarySource?.MediaStreams?.find((s) => s.Type === 'Audio')
+
+  return {
+    videoResolution:
+      videoStream?.Width && videoStream?.Height
+        ? `${videoStream.Width}x${videoStream.Height}`
+        : undefined,
+    videoCodec: videoStream?.Codec,
+    audioCodec: audioStream?.Codec,
+    container: primarySource?.Container,
+  }
+}
+
+export function mapEmbyItemToWatchedMovie(item: EmbyItem): WatchedItem {
+  return {
+    movieId: item.Id,
+    playCount: item.UserData?.PlayCount || 0,
+    isFavorite: item.UserData?.IsFavorite || false,
+    lastPlayedDate: item.UserData?.LastPlayedDate,
+    tmdbId: item.ProviderIds?.Tmdb,
+    imdbId: item.ProviderIds?.Imdb,
+    played: item.UserData?.Played ?? false,
+    playbackPositionTicks: item.UserData?.PlaybackPositionTicks,
+    runtimeTicks: item.RunTimeTicks,
+  }
+}
+
+export function mapEmbyEpisodeToWatched(item: EmbyEpisode): WatchedEpisode {
+  return {
+    episodeId: item.Id,
+    seriesId: item.SeriesId,
+    seasonNumber: item.ParentIndexNumber,
+    episodeNumber: item.IndexNumber,
+    playCount: item.UserData?.PlayCount || 0,
+    isFavorite: item.UserData?.IsFavorite || false,
+    lastPlayedDate: item.UserData?.LastPlayedDate,
+    tmdbId: item.ProviderIds?.Tmdb,
+    imdbId: item.ProviderIds?.Imdb,
+    tvdbId: item.ProviderIds?.Tvdb,
+    played: item.UserData?.Played ?? false,
+    playbackPositionTicks: item.UserData?.PlaybackPositionTicks,
+    runtimeTicks: item.RunTimeTicks,
+  }
+}
+
+export function seriesEndYear(endDate: string | undefined): number | undefined {
+  if (!endDate) {
+    return undefined
+  }
+  return new Date(endDate).getFullYear()
+}

--- a/packages/core/src/media/emby/mappers.ts
+++ b/packages/core/src/media/emby/mappers.ts
@@ -1,28 +1,24 @@
 import type { EmbyItem, EmbySeries, EmbyEpisode } from './types.js'
 import type { Movie, Series, Episode } from '../types.js'
+import {
+  extractPeopleNames,
+  mapEmbyActors,
+  mapEmbyGuestStars,
+  mapEmbyMediaSources,
+  mapEmbyStudios,
+  mapEmbyUserData,
+  mapEmbyVideoQuality,
+  seriesEndYear,
+} from './mapperHelpers.js'
 
-/**
- * Map an Emby item to the internal Movie type
- */
+export { mapEmbyEpisodeToWatched, mapEmbyItemToWatchedMovie } from './mapperHelpers.js'
+
 export function mapEmbyItemToMovie(item: EmbyItem, baseUrl: string): Movie {
-  // Extract people by type
-  const directors = item.People?.filter((p) => p.Type === 'Director').map((p) => p.Name) || []
-  const writers = item.People?.filter((p) => p.Type === 'Writer').map((p) => p.Name) || []
-  const actors =
-    item.People?.filter((p) => p.Type === 'Actor')
-      .slice(0, 20)
-      .map((p) => ({
-        name: p.Name,
-        role: p.Role,
-        ...(p.Id ? { personId: String(p.Id) } : {}),
-        // Use Persons endpoint for actor images
-        thumb: p.Name ? `${baseUrl}/Persons/${encodeURIComponent(p.Name)}/Images/Primary` : undefined,
-      })) || []
-
-  // Extract video/audio info from first media source
+  const directors = extractPeopleNames(item.People, ['Director'])
+  const writers = extractPeopleNames(item.People, ['Writer'])
+  const actors = mapEmbyActors(item.People, baseUrl)
   const primarySource = item.MediaSources?.[0]
-  const videoStream = primarySource?.MediaStreams?.find((s) => s.Type === 'Video')
-  const audioStream = primarySource?.MediaStreams?.find((s) => s.Type === 'Audio')
+  const quality = mapEmbyVideoQuality(primarySource)
 
   return {
     id: item.Id,
@@ -39,21 +35,11 @@ export function mapEmbyItemToMovie(item: EmbyItem, baseUrl: string): Movie {
     contentRating: item.OfficialRating,
     runtimeTicks: item.RunTimeTicks,
     path: item.Path,
-    mediaSources: item.MediaSources?.map((ms) => ({
-      id: ms.Id,
-      path: ms.Path,
-      container: ms.Container,
-      size: ms.Size,
-      bitrate: ms.Bitrate,
-    })),
+    mediaSources: mapEmbyMediaSources(item.MediaSources),
     posterImageTag: item.ImageTags?.Primary,
     backdropImageTag: item.BackdropImageTags?.[0] || item.ImageTags?.Backdrop,
     parentId: item.ParentId,
-    // New metadata fields - include studio IDs for image lookups
-    studios: item.Studios?.map((s) => ({
-      id: s.Id?.toString(),
-      name: s.Name,
-    })) || [],
+    studios: mapEmbyStudios(item.Studios),
     directors,
     writers,
     actors,
@@ -62,49 +48,15 @@ export function mapEmbyItemToMovie(item: EmbyItem, baseUrl: string): Movie {
     tags: item.Tags || [],
     productionCountries: item.ProductionLocations || [],
     awards: item.Awards,
-    // Video/audio quality
-    videoResolution:
-      videoStream?.Width && videoStream?.Height
-        ? `${videoStream.Width}x${videoStream.Height}`
-        : undefined,
-    videoCodec: videoStream?.Codec,
-    audioCodec: audioStream?.Codec,
-    container: primarySource?.Container,
-    userData: item.UserData
-      ? {
-          playCount: item.UserData.PlayCount,
-          isFavorite: item.UserData.IsFavorite,
-          lastPlayedDate: item.UserData.LastPlayedDate,
-          playbackPositionTicks: item.UserData.PlaybackPositionTicks,
-          played: item.UserData.Played,
-        }
-      : undefined,
+    ...quality,
+    userData: mapEmbyUserData(item.UserData, true),
   }
 }
 
-/**
- * Map an Emby series to the internal Series type
- */
 export function mapEmbyItemToSeries(item: EmbySeries, baseUrl: string): Series {
-  // Extract people by type
-  const directors = item.People?.filter((p) => p.Type === 'Director' || p.Type === 'Creator').map((p) => p.Name) || []
-  const writers = item.People?.filter((p) => p.Type === 'Writer').map((p) => p.Name) || []
-  const actors =
-    item.People?.filter((p) => p.Type === 'Actor')
-      .slice(0, 20)
-      .map((p) => ({
-        name: p.Name,
-        role: p.Role,
-        ...(p.Id ? { personId: String(p.Id) } : {}),
-        // Use Persons endpoint for actor images
-        thumb: p.Name ? `${baseUrl}/Persons/${encodeURIComponent(p.Name)}/Images/Primary` : undefined,
-      })) || []
-
-  // Extract end year from EndDate if available
-  let endYear: number | undefined
-  if (item.EndDate) {
-    endYear = new Date(item.EndDate).getFullYear()
-  }
+  const directors = extractPeopleNames(item.People, ['Director', 'Creator'])
+  const writers = extractPeopleNames(item.People, ['Writer'])
+  const actors = mapEmbyActors(item.People, baseUrl)
 
   return {
     id: item.Id,
@@ -112,7 +64,7 @@ export function mapEmbyItemToSeries(item: EmbySeries, baseUrl: string): Series {
     originalTitle: item.OriginalTitle,
     sortName: item.SortName,
     year: item.ProductionYear,
-    endYear,
+    endYear: seriesEndYear(item.EndDate),
     premiereDate: item.PremiereDate,
     genres: item.Genres || [],
     overview: item.Overview,
@@ -128,10 +80,7 @@ export function mapEmbyItemToSeries(item: EmbySeries, baseUrl: string): Series {
     posterImageTag: item.ImageTags?.Primary,
     backdropImageTag: item.BackdropImageTags?.[0] || item.ImageTags?.Backdrop,
     parentId: item.ParentId,
-    studios: item.Studios?.map((s) => ({
-      id: s.Id?.toString(),
-      name: s.Name,
-    })) || [],
+    studios: mapEmbyStudios(item.Studios),
     directors,
     writers,
     actors,
@@ -141,33 +90,14 @@ export function mapEmbyItemToSeries(item: EmbySeries, baseUrl: string): Series {
     tags: item.Tags || [],
     productionCountries: item.ProductionLocations || [],
     awards: item.Awards,
-    userData: item.UserData
-      ? {
-          playCount: item.UserData.PlayCount,
-          isFavorite: item.UserData.IsFavorite,
-          lastPlayedDate: item.UserData.LastPlayedDate,
-          played: item.UserData.Played,
-        }
-      : undefined,
+    userData: mapEmbyUserData(item.UserData),
   }
 }
 
-/**
- * Map an Emby episode to the internal Episode type
- */
 export function mapEmbyItemToEpisode(item: EmbyEpisode, baseUrl: string): Episode {
-  // Extract people by type
-  const directors = item.People?.filter((p) => p.Type === 'Director').map((p) => p.Name) || []
-  const writers = item.People?.filter((p) => p.Type === 'Writer').map((p) => p.Name) || []
-  const guestStars =
-    item.People?.filter((p) => p.Type === 'GuestStar')
-      .slice(0, 10)
-      .map((p) => ({
-        name: p.Name,
-        role: p.Role,
-        // Use Persons endpoint for person images
-        thumb: p.Name ? `${baseUrl}/Persons/${encodeURIComponent(p.Name)}/Images/Primary` : undefined,
-      })) || []
+  const directors = extractPeopleNames(item.People, ['Director'])
+  const writers = extractPeopleNames(item.People, ['Writer'])
+  const guestStars = mapEmbyGuestStars(item.People, baseUrl)
 
   return {
     id: item.Id,
@@ -183,25 +113,10 @@ export function mapEmbyItemToEpisode(item: EmbyEpisode, baseUrl: string): Episod
     communityRating: item.CommunityRating,
     posterImageTag: item.ImageTags?.Primary,
     path: item.Path,
-    mediaSources: item.MediaSources?.map((ms) => ({
-      id: ms.Id,
-      path: ms.Path,
-      container: ms.Container,
-      size: ms.Size,
-      bitrate: ms.Bitrate,
-    })),
+    mediaSources: mapEmbyMediaSources(item.MediaSources),
     directors,
     writers,
     guestStars,
-    userData: item.UserData
-      ? {
-          playCount: item.UserData.PlayCount,
-          isFavorite: item.UserData.IsFavorite,
-          lastPlayedDate: item.UserData.LastPlayedDate,
-          playbackPositionTicks: item.UserData.PlaybackPositionTicks,
-          played: item.UserData.Played,
-        }
-      : undefined,
+    userData: mapEmbyUserData(item.UserData, true),
   }
 }
-

--- a/packages/core/src/media/emby/movies.ts
+++ b/packages/core/src/media/emby/movies.ts
@@ -4,55 +4,25 @@
 
 import type { Movie, PaginationOptions, PaginatedResult, WatchedItem } from '../types.js'
 import type { EmbyItem, EmbyItemsResponse, EmbyActivityResponse } from './types.js'
-import { mapEmbyItemToMovie } from './mappers.js'
+import { mapEmbyItemToMovie, mapEmbyItemToWatchedMovie } from './mappers.js'
 import { logger, type EmbyProviderBase } from './base.js'
 import { mergeWatchedItems } from '../watchHistoryHelpers.js'
-
-const MOVIE_WATCH_FIELDS =
-  'UserData,UserDataPlayCount,UserDataLastPlayedDate,ProviderIds,RunTimeTicks'
+import {
+  buildPaginatedItemsParams,
+  MOVIE_LIST_FIELDS,
+  MOVIE_WATCH_FIELDS,
+} from './requestBuilders.js'
 
 export async function getMovies(
   provider: EmbyProviderBase,
   apiKey: string,
   options: PaginationOptions = {}
 ): Promise<PaginatedResult<Movie>> {
-  const params = new URLSearchParams({
-    IncludeItemTypes: 'Movie',
-    Recursive: 'true',
-    // Request comprehensive metadata from Emby
-    Fields: [
-      'Overview',
-      'Genres',
-      'ProductionYear',
-      'CommunityRating',
-      'CriticRating',
-      'Path',
-      'MediaSources',
-      'OriginalTitle',
-      'ParentId',
-      'SortName',
-      'Tagline',
-      'OfficialRating',
-      'PremiereDate',
-      'Studios',
-      'People',
-      'ProviderIds',
-      'Tags',
-      'ProductionLocations',
-      'Awards',
-      'ImageTags',
-      'BackdropImageTags',
-    ].join(','),
-    StartIndex: String(options.startIndex || 0),
-    Limit: String(options.limit || 100),
-    SortBy: options.sortBy || 'SortName',
-    SortOrder: options.sortOrder || 'Ascending',
+  const params = buildPaginatedItemsParams({
+    ...options,
+    includeItemTypes: 'Movie',
+    fields: MOVIE_LIST_FIELDS,
   })
-
-  // Filter by parent library IDs if provided
-  if (options.parentIds && options.parentIds.length > 0) {
-    params.set('ParentId', options.parentIds.join(','))
-  }
 
   logger.info(
     {
@@ -170,7 +140,7 @@ async function getWatchHistoryFromItems(
   const itemsMap = new Map<string, WatchedItem>()
 
   const upsertMovie = (item: EmbyItem) => {
-    const mapped = watchedItemFromEmbyMovie(item)
+    const mapped = mapEmbyItemToWatchedMovie(item)
     const existing = itemsMap.get(item.Id)
     itemsMap.set(item.Id, existing ? mergeWatchedItems(existing, mapped) : mapped)
   }
@@ -257,7 +227,7 @@ async function getWatchHistoryFromItems(
   let addedFavorites = 0
   for (const item of favoritesResponse.Items) {
     if (!itemsMap.has(item.Id)) {
-      itemsMap.set(item.Id, watchedItemFromEmbyMovie(item))
+      itemsMap.set(item.Id, mapEmbyItemToWatchedMovie(item))
       addedFavorites++
     } else {
       const existing = itemsMap.get(item.Id)!
@@ -290,20 +260,6 @@ async function getWatchHistoryFromItems(
     'Watch history from Items API complete'
   )
   return allItems
-}
-
-function watchedItemFromEmbyMovie(item: EmbyItem): WatchedItem {
-  return {
-    movieId: item.Id,
-    playCount: item.UserData?.PlayCount || 0,
-    isFavorite: item.UserData?.IsFavorite || false,
-    lastPlayedDate: item.UserData?.LastPlayedDate,
-    tmdbId: item.ProviderIds?.Tmdb,
-    imdbId: item.ProviderIds?.Imdb,
-    played: item.UserData?.Played ?? false,
-    playbackPositionTicks: item.UserData?.PlaybackPositionTicks,
-    runtimeTicks: item.RunTimeTicks,
-  }
 }
 
 /**

--- a/packages/core/src/media/emby/playlists.ts
+++ b/packages/core/src/media/emby/playlists.ts
@@ -5,6 +5,14 @@
 import type { PlaylistCreateResult, PlaylistItem } from '../types.js'
 import type { EmbyItemsResponse } from './types.js'
 import { logger, type EmbyProviderBase } from './base.js'
+import { updateEmbyItem } from './itemUpdates.js'
+import {
+  buildItemSearchParams,
+  buildPlaylistCreateParams,
+  playlistAddItemsPath,
+  playlistItemsPath,
+  playlistRemoveItemsPath,
+} from './requestBuilders.js'
 
 export async function createOrUpdatePlaylist(
   provider: EmbyProviderBase,
@@ -13,34 +21,29 @@ export async function createOrUpdatePlaylist(
   name: string,
   itemIds: string[]
 ): Promise<PlaylistCreateResult> {
-  // First, try to find existing playlist
-  const params = new URLSearchParams({
-    IncludeItemTypes: 'Playlist',
-    Recursive: 'true',
-    SearchTerm: name,
-    UserId: userId,
+  const params = buildItemSearchParams({
+    includeItemTypes: 'Playlist',
+    searchTerm: name,
+    userId,
   })
 
   const existing = await provider.fetch<EmbyItemsResponse>(`/Items?${params}`, apiKey)
   const playlist = existing.Items.find((p) => p.Name === name)
 
   if (playlist) {
-    // Get existing items to delete them by entry ID
     const existingItems = await provider.fetch<{
       Items: Array<{ PlaylistItemId: string }>
-    }>(`/Playlists/${playlist.Id}/Items`, apiKey)
+    }>(playlistItemsPath(playlist.Id), apiKey)
 
-    // Remove all existing items if any
     if (existingItems.Items && existingItems.Items.length > 0) {
-      const entryIds = existingItems.Items.map((item) => item.PlaylistItemId).join(',')
-      await provider.fetch(`/Playlists/${playlist.Id}/Items?EntryIds=${entryIds}`, apiKey, {
+      const entryIds = existingItems.Items.map((item) => item.PlaylistItemId)
+      await provider.fetch(playlistRemoveItemsPath(playlist.Id, entryIds), apiKey, {
         method: 'DELETE',
       })
     }
 
-    // Add new items
     if (itemIds.length > 0) {
-      await provider.fetch(`/Playlists/${playlist.Id}/Items?Ids=${itemIds.join(',')}`, apiKey, {
+      await provider.fetch(playlistAddItemsPath(playlist.Id, itemIds), apiKey, {
         method: 'POST',
       })
     }
@@ -48,16 +51,7 @@ export async function createOrUpdatePlaylist(
     return { playlistId: playlist.Id }
   }
 
-  // Create new playlist
-  const createParams = new URLSearchParams({
-    Name: name,
-    UserId: userId,
-    MediaType: 'Video',
-  })
-
-  if (itemIds.length > 0) {
-    createParams.set('Ids', itemIds.join(','))
-  }
+  const createParams = buildPlaylistCreateParams(name, userId, itemIds)
 
   const created = await provider.fetch<{ Id: string }>(`/Playlists?${createParams}`, apiKey, {
     method: 'POST',
@@ -88,7 +82,7 @@ export async function getPlaylistItems(
       ImageTags?: { Primary?: string }
       RunTimeTicks?: number
     }>
-  }>(`/Playlists/${playlistId}/Items?Fields=ImageTags,ProductionYear,RunTimeTicks`, apiKey)
+  }>(`${playlistItemsPath(playlistId)}?Fields=ImageTags,ProductionYear,RunTimeTicks`, apiKey)
 
   return response.Items.map((item) => ({
     id: item.Id,
@@ -109,7 +103,7 @@ export async function removePlaylistItems(
   entryIds: string[]
 ): Promise<void> {
   if (entryIds.length === 0) return
-  await provider.fetch(`/Playlists/${playlistId}/Items?EntryIds=${entryIds.join(',')}`, apiKey, {
+  await provider.fetch(playlistRemoveItemsPath(playlistId, entryIds), apiKey, {
     method: 'DELETE',
   })
 }
@@ -121,7 +115,7 @@ export async function addPlaylistItems(
   itemIds: string[]
 ): Promise<void> {
   if (itemIds.length === 0) return
-  await provider.fetch(`/Playlists/${playlistId}/Items?Ids=${itemIds.join(',')}`, apiKey, {
+  await provider.fetch(playlistAddItemsPath(playlistId, itemIds), apiKey, {
     method: 'POST',
   })
 }
@@ -141,13 +135,6 @@ export async function getGenres(provider: EmbyProviderBase, apiKey: string): Pro
   return response.Items.map((item) => item.Name)
 }
 
-/**
- * Update playlist overview/description
- * Emby requires posting the full item object back when updating metadata
- * 
- * Note: GET requires user context (/Users/{userId}/Items/{id})
- *       POST uses /Items/{ItemId} with the item's Id from the response
- */
 export async function updatePlaylistOverview(
   provider: EmbyProviderBase,
   apiKey: string,
@@ -156,39 +143,22 @@ export async function updatePlaylistOverview(
   overview: string
 ): Promise<void> {
   logger.info({ userId, playlistId, overviewLength: overview?.length }, 'Updating playlist overview')
-  
+
   try {
-    // Fetch the full item data using user context (required for playlists)
-    logger.debug({ endpoint: `/Users/${userId}/Items/${playlistId}` }, 'Fetching playlist item')
-    const item = await provider.fetch<Record<string, unknown>>(
+    const itemId = await updateEmbyItem(
+      provider,
+      apiKey,
       `/Users/${userId}/Items/${playlistId}`,
-      apiKey
+      (item) => {
+        item.Overview = overview
+      }
     )
-    
-    // Use the item's actual Id for the POST (may differ from playlistId)
-    const itemId = (item.Id as string) || playlistId
-    logger.debug({ itemName: item.Name, itemId, playlistId }, 'Fetched playlist item')
-
-    // Update the overview
-    item.Overview = overview
-
-    // POST the full item back using the item's Id
-    logger.debug({ endpoint: `/Items/${itemId}` }, 'Posting updated item')
-    await provider.fetch(`/Items/${itemId}`, apiKey, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(item),
-    })
     logger.info({ playlistId, itemId }, 'Successfully updated playlist overview')
   } catch (err) {
-    // Log the full error for debugging
     logger.error({ err, userId, playlistId }, 'Failed to set overview for playlist')
   }
 }
 
-/**
- * Create a new playlist with items and optional overview
- */
 export async function createPlaylistWithOverview(
   provider: EmbyProviderBase,
   apiKey: string,
@@ -197,20 +167,14 @@ export async function createPlaylistWithOverview(
   itemIds: string[],
   overview?: string
 ): Promise<PlaylistCreateResult> {
-  // Create the playlist first
   const result = await createOrUpdatePlaylist(provider, apiKey, userId, name, itemIds)
-  
+
   logger.info({ playlistId: result.playlistId, hasOverview: !!overview }, 'Playlist created, setting overview')
 
-  // Set overview if provided
   if (overview) {
-    // Small delay to ensure Emby has fully registered the playlist
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await new Promise((resolve) => setTimeout(resolve, 500))
     await updatePlaylistOverview(provider, apiKey, userId, result.playlistId, overview)
   }
 
   return result
 }
-
-
-

--- a/packages/core/src/media/emby/requestBuilders.ts
+++ b/packages/core/src/media/emby/requestBuilders.ts
@@ -1,0 +1,169 @@
+/**
+ * Emby API request builders — URL params and endpoint paths for items, playlists, and collections.
+ */
+
+import type { PaginationOptions } from '../types.js'
+
+export const MOVIE_LIST_FIELDS = [
+  'Overview',
+  'Genres',
+  'ProductionYear',
+  'CommunityRating',
+  'CriticRating',
+  'Path',
+  'MediaSources',
+  'OriginalTitle',
+  'ParentId',
+  'SortName',
+  'Tagline',
+  'OfficialRating',
+  'PremiereDate',
+  'Studios',
+  'People',
+  'ProviderIds',
+  'Tags',
+  'ProductionLocations',
+  'Awards',
+  'ImageTags',
+  'BackdropImageTags',
+] as const
+
+export const SERIES_LIST_FIELDS = [
+  'Overview',
+  'Genres',
+  'ProductionYear',
+  'CommunityRating',
+  'CriticRating',
+  'OriginalTitle',
+  'ParentId',
+  'SortName',
+  'Tagline',
+  'OfficialRating',
+  'PremiereDate',
+  'EndDate',
+  'Studios',
+  'People',
+  'ProviderIds',
+  'Tags',
+  'ProductionLocations',
+  'Awards',
+  'Status',
+  'AirDays',
+  'ChildCount',
+  'RecursiveItemCount',
+  'ImageTags',
+  'BackdropImageTags',
+] as const
+
+export const EPISODE_LIST_FIELDS = [
+  'Overview',
+  'ProductionYear',
+  'CommunityRating',
+  'PremiereDate',
+  'Path',
+  'MediaSources',
+  'People',
+  'SeriesName',
+] as const
+
+export const MOVIE_WATCH_FIELDS =
+  'UserData,UserDataPlayCount,UserDataLastPlayedDate,ProviderIds,RunTimeTicks'
+
+export const EPISODE_WATCH_FIELDS =
+  'UserData,UserDataPlayCount,UserDataLastPlayedDate,SeriesId,ParentIndexNumber,IndexNumber,ProviderIds,RunTimeTicks'
+
+export function buildItemSearchParams(options: {
+  includeItemTypes: string
+  searchTerm: string
+  recursive?: boolean
+  userId?: string
+}): URLSearchParams {
+  const params = new URLSearchParams({
+    IncludeItemTypes: options.includeItemTypes,
+    Recursive: String(options.recursive ?? true),
+    SearchTerm: options.searchTerm,
+  })
+
+  if (options.userId) {
+    params.set('UserId', options.userId)
+  }
+
+  return params
+}
+
+export function buildPaginatedItemsParams(
+  options: PaginationOptions & {
+    includeItemTypes: string
+    fields: readonly string[]
+    defaultSortBy?: string
+    seriesId?: string
+  }
+): URLSearchParams {
+  const params = new URLSearchParams({
+    IncludeItemTypes: options.includeItemTypes,
+    Recursive: 'true',
+    Fields: options.fields.join(','),
+    StartIndex: String(options.startIndex || 0),
+    Limit: String(options.limit || 100),
+    SortBy: options.sortBy || options.defaultSortBy || 'SortName',
+    SortOrder: options.sortOrder || 'Ascending',
+  })
+
+  if (options.parentIds && options.parentIds.length > 0) {
+    params.set('ParentId', options.parentIds.join(','))
+  }
+
+  if (options.seriesId) {
+    params.set('SeriesId', options.seriesId)
+  }
+
+  return params
+}
+
+export function buildPlaylistCreateParams(
+  name: string,
+  userId: string,
+  itemIds: string[]
+): URLSearchParams {
+  const params = new URLSearchParams({
+    Name: name,
+    UserId: userId,
+    MediaType: 'Video',
+  })
+
+  if (itemIds.length > 0) {
+    params.set('Ids', itemIds.join(','))
+  }
+
+  return params
+}
+
+export function buildCollectionCreateParams(name: string, itemIds: string[]): URLSearchParams {
+  const params = new URLSearchParams({ Name: name })
+
+  if (itemIds.length > 0) {
+    params.set('Ids', itemIds.join(','))
+  }
+
+  return params
+}
+
+export function playlistItemsPath(playlistId: string): string {
+  return `/Playlists/${playlistId}/Items`
+}
+
+export function playlistAddItemsPath(playlistId: string, itemIds: string[]): string {
+  return `${playlistItemsPath(playlistId)}?Ids=${itemIds.join(',')}`
+}
+
+export function playlistRemoveItemsPath(playlistId: string, entryIds: string[]): string {
+  return `${playlistItemsPath(playlistId)}?EntryIds=${entryIds.join(',')}`
+}
+
+export function collectionItemsPath(collectionId: string, itemIds: string[]): string {
+  return `/Collections/${collectionId}/Items?Ids=${itemIds.join(',')}`
+}
+
+export function collectionChildItemsQuery(collectionId: string): string {
+  return `/Items?ParentId=${collectionId}&Recursive=true`
+}

--- a/packages/core/src/media/emby/series.ts
+++ b/packages/core/src/media/emby/series.ts
@@ -10,56 +10,26 @@ import type {
   WatchedEpisode,
 } from '../types.js'
 import type { EmbySeries, EmbyEpisode } from './types.js'
-import { mapEmbyItemToSeries, mapEmbyItemToEpisode } from './mappers.js'
+import { mapEmbyItemToSeries, mapEmbyItemToEpisode, mapEmbyEpisodeToWatched } from './mappers.js'
 import { logger, type EmbyProviderBase } from './base.js'
 import { mergeWatchedEpisodes } from '../watchHistoryHelpers.js'
-
-const EPISODE_WATCH_FIELDS =
-  'UserData,UserDataPlayCount,UserDataLastPlayedDate,SeriesId,ParentIndexNumber,IndexNumber,ProviderIds,RunTimeTicks'
+import {
+  buildPaginatedItemsParams,
+  EPISODE_LIST_FIELDS,
+  EPISODE_WATCH_FIELDS,
+  SERIES_LIST_FIELDS,
+} from './requestBuilders.js'
 
 export async function getSeries(
   provider: EmbyProviderBase,
   apiKey: string,
   options: PaginationOptions = {}
 ): Promise<PaginatedResult<Series>> {
-  const params = new URLSearchParams({
-    IncludeItemTypes: 'Series',
-    Recursive: 'true',
-    Fields: [
-      'Overview',
-      'Genres',
-      'ProductionYear',
-      'CommunityRating',
-      'CriticRating',
-      'OriginalTitle',
-      'ParentId',
-      'SortName',
-      'Tagline',
-      'OfficialRating',
-      'PremiereDate',
-      'EndDate',
-      'Studios',
-      'People',
-      'ProviderIds',
-      'Tags',
-      'ProductionLocations',
-      'Awards',
-      'Status',
-      'AirDays',
-      'ChildCount',
-      'RecursiveItemCount',
-      'ImageTags',
-      'BackdropImageTags',
-    ].join(','),
-    StartIndex: String(options.startIndex || 0),
-    Limit: String(options.limit || 100),
-    SortBy: options.sortBy || 'SortName',
-    SortOrder: options.sortOrder || 'Ascending',
+  const params = buildPaginatedItemsParams({
+    ...options,
+    includeItemTypes: 'Series',
+    fields: SERIES_LIST_FIELDS,
   })
-
-  if (options.parentIds && options.parentIds.length > 0) {
-    params.set('ParentId', options.parentIds.join(','))
-  }
 
   logger.info(
     {
@@ -114,32 +84,13 @@ export async function getEpisodes(
   apiKey: string,
   options: PaginationOptions & { seriesId?: string } = {}
 ): Promise<PaginatedResult<Episode>> {
-  const params = new URLSearchParams({
-    IncludeItemTypes: 'Episode',
-    Recursive: 'true',
-    Fields: [
-      'Overview',
-      'ProductionYear',
-      'CommunityRating',
-      'PremiereDate',
-      'Path',
-      'MediaSources',
-      'People',
-      'SeriesName',
-    ].join(','),
-    StartIndex: String(options.startIndex || 0),
-    Limit: String(options.limit || 100),
-    SortBy: options.sortBy || 'SeriesSortName,SortName',
-    SortOrder: options.sortOrder || 'Ascending',
+  const params = buildPaginatedItemsParams({
+    ...options,
+    includeItemTypes: 'Episode',
+    fields: EPISODE_LIST_FIELDS,
+    defaultSortBy: 'SeriesSortName,SortName',
+    seriesId: options.seriesId,
   })
-
-  if (options.seriesId) {
-    params.set('SeriesId', options.seriesId)
-  }
-
-  if (options.parentIds && options.parentIds.length > 0) {
-    params.set('ParentId', options.parentIds.join(','))
-  }
 
   logger.info(
     {
@@ -200,7 +151,7 @@ export async function getSeriesWatchHistory(
   const itemsMap = new Map<string, WatchedEpisode>()
 
   const upsertEpisode = (item: EmbyEpisode) => {
-    const mapped = watchedEpisodeFromEmbyItem(item)
+    const mapped = mapEmbyEpisodeToWatched(item)
     const existing = itemsMap.get(item.Id)
     itemsMap.set(item.Id, existing ? mergeWatchedEpisodes(existing, mapped) : mapped)
   }
@@ -291,7 +242,7 @@ export async function getSeriesWatchHistory(
   let addedFavorites = 0
   for (const item of favoritesResponse.Items) {
     if (!itemsMap.has(item.Id)) {
-      const favorite = watchedEpisodeFromEmbyItem(item)
+      const favorite = mapEmbyEpisodeToWatched(item)
       favorite.isFavorite = true
       itemsMap.set(item.Id, favorite)
       addedFavorites++
@@ -322,24 +273,6 @@ export async function getSeriesWatchHistory(
 
   logger.info({ userId, totalItems: allItems.length }, 'Series watch history complete')
   return allItems
-}
-
-function watchedEpisodeFromEmbyItem(item: EmbyEpisode): WatchedEpisode {
-  return {
-    episodeId: item.Id,
-    seriesId: item.SeriesId,
-    seasonNumber: item.ParentIndexNumber,
-    episodeNumber: item.IndexNumber,
-    playCount: item.UserData?.PlayCount || 0,
-    isFavorite: item.UserData?.IsFavorite || false,
-    lastPlayedDate: item.UserData?.LastPlayedDate,
-    tmdbId: item.ProviderIds?.Tmdb,
-    imdbId: item.ProviderIds?.Imdb,
-    tvdbId: item.ProviderIds?.Tvdb,
-    played: item.UserData?.Played ?? false,
-    playbackPositionTicks: item.UserData?.PlaybackPositionTicks,
-    runtimeTicks: item.RunTimeTicks,
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract shared Emby helpers for fetch error handling, request builders, item updates, and mappers
- Refactor base, movies, series, playlists, collections, favorites, and mappers to use helpers without behavior changes
- Export helper modules from the Emby provider index

## Test plan
- [x] `pnpm validate`
- [ ] Smoke-test Emby playlist/collection create/update against a live server
- [ ] Verify watch history sync still maps movies/episodes correctly